### PR TITLE
Memory clean up

### DIFF
--- a/src/bvh/boundable.cpp
+++ b/src/bvh/boundable.cpp
@@ -72,6 +72,7 @@ void Sphere::calculateBounds(const vec3 normalPlanes[], const int planeSize, con
         outputExtent->d[i][0] = std::min(d1, d2);
         outputExtent->d[i][1] = std::max(d1, d2);
     }
+    outputExtent->object = this;
 }
 
 bool Sphere::hit(const ray& ray, const double t_min, const double t_max, hit_record &rec) const{
@@ -103,4 +104,11 @@ bool Sphere::hit(const ray& ray, const double t_min, const double t_max, hit_rec
   rec.set_face_normal(ray, outward_normal);
   rec.mat_ptr = this->mat_ptr;
   return true;
+}
+
+Sphere::~Sphere(){
+    if(mat_ptr != nullptr){
+        delete mat_ptr;
+        mat_ptr = nullptr;
+    }
 }

--- a/src/bvh/boundable.h
+++ b/src/bvh/boundable.h
@@ -38,6 +38,7 @@ class Sphere: public Boundable{
     public:
     Sphere(vec3 center, double r);
     Sphere(vec3 center, double r, material*material);
+    ~Sphere();
     void calculateBounds(const vec3 normalPlanes[], const int planeSize, const vec3 origin, Extent* &outputExtent) override;
     bool hit(const ray& ray, double t_min, double t_max, hit_record &rec) const;
     vec3 center;

--- a/src/bvh/bvh.cpp
+++ b/src/bvh/bvh.cpp
@@ -50,6 +50,7 @@ void Octree::deleteOctreeNode(OctreeNode *&node)
         if (node->child[i] != nullptr)
         {
             deleteOctreeNode(node->child[i]);
+            node->child[i] = nullptr;
         }
     }
     delete node;
@@ -159,6 +160,13 @@ void Octree::build(){
     build(root, bbox);
 }
 
+Octree::~Octree(){
+    if(root!=nullptr){
+        deleteOctreeNode(root);
+        root=nullptr;
+    }
+}
+
 const vec3 BVH::planeSetNormals[kNumPlaneSetNormals] = {
     vec3(1, 0, 0),
     vec3(0, 1, 0),
@@ -179,8 +187,6 @@ BVH::BVH(std::vector<Sphere*>& objects){
         Extent* objectExtent;
         objects[i]->calculateBounds(planeSetNormals, kNumPlaneSetNormals, vec3(0), objectExtent);
         scene->extendBy(objectExtent);
-        objectExtent->object = objects[i];
-        auto ptr = objectExtent->object;
         extentList.push_back(objectExtent);
     }
     tree = new Octree(scene);
@@ -193,7 +199,16 @@ BVH::BVH(std::vector<Sphere*>& objects){
 }
 
 BVH::~BVH(){
-    delete tree;
+    if(tree!=nullptr){
+        delete tree;
+        tree = nullptr;
+    }
+    for(int i=0; i<extentList.size(); i++){
+        if(extentList[i]!=nullptr){
+            delete extentList[i];
+            extentList[i] = nullptr;
+        }
+    }
 }
 
 bool BVH::intersect(const ray &ray, Sphere **hit_object, hit_record& hit_record_out){

--- a/src/bvh/bvh.cpp
+++ b/src/bvh/bvh.cpp
@@ -196,6 +196,7 @@ BVH::BVH(std::vector<Sphere*>& objects){
     }
 
     tree->build();
+    delete scene;
 }
 
 BVH::~BVH(){

--- a/src/bvh/bvh.hpp
+++ b/src/bvh/bvh.hpp
@@ -8,66 +8,74 @@
 #include "boundable.h"
 #include "hittable.h"
 
-
-class BBox 
-{ 
-public: 
-    BBox() {} 
+class BBox
+{
+public:
+    BBox() {}
     BBox(vec3 min, vec3 max);
-    BBox& extendBy(const vec3& p);
-    vec3 centroid() const { return (bounds[0] + bounds[1]) * 0.5; } 
-    vec3& operator [] (bool i) { return bounds[i]; } 
-    const vec3 operator [] (bool i) const { return bounds[i]; } 
-    vec3 bounds[2] = {vec3(DBL_MIN), vec3(DBL_MAX)}; 
-}; 
+    BBox &extendBy(const vec3 &p);
+    vec3 centroid() const { return (bounds[0] + bounds[1]) * 0.5; }
+    vec3 &operator[](bool i) { return bounds[i]; }
+    const vec3 operator[](bool i) const { return bounds[i]; }
+    vec3 bounds[2] = {vec3(DBL_MIN), vec3(DBL_MAX)};
+};
 
 struct OctreeNode
 {
     OctreeNode *child[8] = {nullptr};
     std::vector<const Extent *> nodeExtentsList; // pointer to the objects extents
-    Extent* currentNodeExtent;                    // extent of the octree node itself
+    Extent *currentNodeExtent;                   // extent of the octree node itself
     bool isLeaf = true;
-    OctreeNode(){
+    OctreeNode()
+    {
         currentNodeExtent = new Extent();
     }
-    ~OctreeNode(){
-        delete currentNodeExtent;
-        currentNodeExtent = nullptr;
+    ~OctreeNode()
+    {
+        if (currentNodeExtent != nullptr)
+        {
+            delete currentNodeExtent;
+            currentNodeExtent = nullptr;
+        }
     }
 };
 
-struct QueueElement 
-{ 
-            const OctreeNode *node; // octree node held by this element in the queue 
-            double t; // distance from the ray origin to the extents of the node 
-            QueueElement(const OctreeNode *n, double tn) : node(n), t(tn) {} 
-            // priority_queue behaves like a min-heap
-            friend bool operator < (const QueueElement &a, const QueueElement &b) { return a.t > b.t; } 
+struct QueueElement
+{
+    const OctreeNode *node; // octree node held by this element in the queue
+    double t;               // distance from the ray origin to the extents of the node
+    QueueElement(const OctreeNode *n, double tn) : node(n), t(tn) {}
+    // priority_queue behaves like a min-heap
+    friend bool operator<(const QueueElement &a, const QueueElement &b) { return a.t > b.t; }
 };
 
 class Octree
 {
 public:
-    Octree(const Extent* sceneExtent);
-    void insert(const Extent * extent);
-    void insert(OctreeNode*& node, const Extent* extents, BBox &nodeBox, int depth);
+    Octree(const Extent *sceneExtent);
+    ~Octree();
+    void insert(const Extent *extent);
+    void insert(OctreeNode *&node, const Extent *extents, BBox &nodeBox, int depth);
     OctreeNode *root = nullptr; // make unique son don't have to manage deallocation
-    void build(OctreeNode*& node, const BBox &bbox);
+    void build(OctreeNode *&node, const BBox &bbox);
     void build();
     BBox bbox;
+
 private:
     void deleteOctreeNode(OctreeNode *&node);
 };
 
-class BVH{
-    public:
-    BVH(std::vector<Sphere*>& scene);
+class BVH
+{
+public:
+    BVH(std::vector<Sphere *> &scene);
     ~BVH();
     bool intersect(const ray &ray, Sphere **hit_object, hit_record &hitRecord);
-    Octree *tree = nullptr; 
-    private:
+    Octree *tree = nullptr;
+
+private:
     static const vec3 planeSetNormals[kNumPlaneSetNormals];
-    std::vector<Extent*> extentList;
+    std::vector<Extent *> extentList;
 };
 
 /**
@@ -81,11 +89,10 @@ class BVH{
 void calculateChildBox(const vec3 &objectCentroid, const BBox &nodeBox, BBox &childBox, int &childIndex);
 
 /**
- * @brief Calculate the child bounding box at child index
- * @param[in] parentBox the parent bounding box
+ * @br
+
  * @param[in] childIndex the child box index from 0-7
  * @param[out] childBox the child box
  */
 void childBox_at_index(const BBox &parentBox, int childIndex, BBox &childBox);
 #endif
-

--- a/src/bvh/sphere_bvh.cpp
+++ b/src/bvh/sphere_bvh.cpp
@@ -11,65 +11,63 @@
 BVH random_scene()
 {
 
-    std::vector<Sphere*> sceneObjects;
-    auto ground_material = new lambertian(color(0.5, 0.5, 0.5));
-    //add ground
-    sceneObjects.push_back(new Sphere(point3(0, -1000, 0), 1000, dynamic_cast<material*>(ground_material)));
+  std::vector<Sphere *> sceneObjects;
+  auto ground_material = new lambertian(color(0.5, 0.5, 0.5));
+  //add ground
+  sceneObjects.push_back(new Sphere(point3(0, -1000, 0), 1000, dynamic_cast<material *>(ground_material)));
 
-    auto albedo = color::random(0.5, 1);
-    auto fuzz = random_double(0, 0.5);
-    auto metal_material = new metal(albedo, fuzz);
+  auto albedo = color::random(0.5, 1);
+  auto fuzz = random_double(0, 0.5);
+  auto metal_material = new metal(albedo, fuzz);
 
-    sceneObjects.push_back(new Sphere(point3(0, 2, 1.5), 1, metal_material));
-    BVH world(sceneObjects);
-    return world;
+  sceneObjects.push_back(new Sphere(point3(0, 2, 1.5), 1, metal_material));
+  BVH world(sceneObjects);
+  return world;
 }
 
 BVH static_scene()
 {
-    std::vector<Sphere*> sceneObjects;
-    auto ground_material = new lambertian(color(0.5, 0.5, 0.5));
-    auto glass_material = new dielectric(1.5);
+  std::vector<Sphere *> sceneObjects;
+  auto ground_material = new lambertian(color(0.5, 0.5, 0.5));
+  auto glass_material = new dielectric(1.5);
 
-    //metal
-    auto albedo = color::random(0.5, 1);
-    auto fuzz = random_double(0, 0.5);
-    auto metal_material = new metal(albedo, fuzz);
-    sceneObjects.push_back(new Sphere(point3(0, -1000, 0), 1000, dynamic_cast<material*>(ground_material)));
-    sceneObjects.push_back(new Sphere(point3(5, 1.5, 1), 1, dynamic_cast<material*>(glass_material)));
-    sceneObjects.push_back(new Sphere(point3(1, 1, 1), 1, dynamic_cast<material*>(metal_material)));
-    std::cout << "World created" << std::endl;
-    return BVH(sceneObjects);
+  //metal
+  auto albedo = color::random(0.5, 1);
+  auto fuzz = random_double(0, 0.5);
+  auto metal_material = new metal(albedo, fuzz);
+  sceneObjects.push_back(new Sphere(point3(0, -1000, 0), 1000, dynamic_cast<material *>(ground_material)));
+  sceneObjects.push_back(new Sphere(point3(5, 1.5, 1), 1, dynamic_cast<material *>(glass_material)));
+  sceneObjects.push_back(new Sphere(point3(1, 1, 1), 1, dynamic_cast<material *>(metal_material)));
+  std::cout << "World created" << std::endl;
+  return BVH(sceneObjects);
 }
-
-
 
 color ray_color(const ray &r, BVH &world, int depth)
 {
-    hit_record rec;
-    Sphere *hitObject = nullptr;
+  hit_record rec;
+  Sphere *hitObject = nullptr;
 
-    if (depth <= 0)
-        return color(0, 0, 0);
+  if (depth <= 0)
+    return color(0, 0, 0);
 
-    if (world.intersect(r, &hitObject, rec))
+  if (world.intersect(r, &hitObject, rec))
+  {
+    ray scattered;
+    color attenuation;
+    if (rec.mat_ptr->scatter(r, rec, attenuation, scattered))
     {
-        ray scattered;
-        color attenuation;
-        if (rec.mat_ptr->scatter(r, rec, attenuation, scattered))
-        {
-            return attenuation * ray_color(scattered, world, depth - 1);
-        }
-        else
-        {
-            return color(0, 0, 0);
-        }
+      return attenuation * ray_color(scattered, world, depth - 1);
     }
+    else
+    {
+      return color(0, 0, 0);
+    }
+  }
 
-    //otherwise return the background color
-    vec3 unit_direction = unit_vector(r.direction());
-    auto t = 0.5 * (unit_direction.y() + 1.0);
-    return (1.0 - t) * color(1.0, 1.0, 1.0) + t * color(0.5, 0.7, 1.0);
+  //otherwise return the background color
+  vec3 unit_direction = unit_vector(r.direction());
+  auto t = 0.5 * (unit_direction.y() + 1.0);
+  return (1.0 - t) * color(1.0, 1.0, 1.0) + t * color(0.5, 0.7, 1.0);
 }
 
 // std::vector<std::shared_ptr<Sphere>> load_scene(std::string fileName){
@@ -79,7 +77,7 @@ color ray_color(const ray &r, BVH &world, int depth)
 //   return io.deserialize_Spheres(j);
 // }
 
-int main(int argc, char** argv)
+int main(int argc, char **argv)
 {
 
   // if(argc<2){
@@ -90,69 +88,72 @@ int main(int argc, char** argv)
   // std::string sceneFile = argv[1];
   // std::vector<std::shared_ptr<Sphere>> scene_spheres = load_scene(sceneFile);
 
-    // Image
-    const auto aspect_ratio = 3.0 / 2.0;
-    const int image_width = 1200;
-    const int image_height = static_cast<int>(image_width / aspect_ratio);
-    const int samples_per_pixel = 100;
-    const int max_depth = 10;
+  // Image
+  const auto aspect_ratio = 3.0 / 2.0;
+  const int image_width = 1200;
+  const int image_height = static_cast<int>(image_width / aspect_ratio);
+  const int samples_per_pixel = 100;
+  const int max_depth = 10;
 
   // World
   // BVH world(scene_spheres);
 
-    std::vector<Sphere*> sceneObjects;
+  std::vector<Sphere *> sceneObjects;
+  std::vector<material *> p_materials;
 
   auto ground_material = new lambertian(color(0.5, 0.5, 0.5));
-  sceneObjects.push_back(new Sphere(point3(0, -1000, 0), 1000, dynamic_cast<material*>(ground_material)));
+  sceneObjects.push_back(new Sphere(point3(0, -1000, 0), 1000, dynamic_cast<material *>(ground_material)));
+  p_materials.push_back(ground_material);
 
   for (int a = -11; a < 11; a++)
+  {
+    for (int b = -11; b < 11; b++)
     {
-      for(int b = -11; b < 11; b++)
+      auto choose_mat = random_double();
+      point3 center(a + 0.9 * random_double(), 0.2, b + 0.9 * random_double());
+
+      if ((center - point3(4, 0.2, 0)).length() > 0.9)
+      {
+        material *sphere_material;
+
+        if (choose_mat < 0.8)
         {
-          auto choose_mat = random_double();
-          point3 center(a+0.9*random_double(), 0.2, b + 0.9*random_double());
-
-          if((center - point3(4, 0.2, 0)).length() > 0.9)
-            {
-              material* sphere_material;
-
-              if(choose_mat < 0.8)
-                {
-                  // diffuse
-                  auto albedo = color::random() * color::random();
-                  sphere_material = new lambertian(albedo);
-                  sceneObjects.push_back(new Sphere(center, 0.2, dynamic_cast<material*>(sphere_material)));
-
-                }
-              else if(choose_mat < 0.95)
-                {
-                  // metal
-                  auto albedo = color::random(0.5, 1);
-                  auto fuzz = random_double(0, 0.5);
-                  sphere_material = new metal(albedo, fuzz);
-                  sceneObjects.push_back(new Sphere(center, 0.2, dynamic_cast<material*>(sphere_material)));
-                }
-              else
-                {
-                  // glass
-                  sphere_material = new dielectric(1.5);
-                  sceneObjects.push_back(new Sphere(center, 0.2, dynamic_cast<material*>(sphere_material)));
-
-                }
-            }
+          // diffuse
+          auto albedo = color::random() * color::random();
+          sphere_material = new lambertian(albedo);
+          sceneObjects.push_back(new Sphere(center, 0.2, dynamic_cast<material *>(sphere_material)));
         }
+        else if (choose_mat < 0.95)
+        {
+          // metal
+          auto albedo = color::random(0.5, 1);
+          auto fuzz = random_double(0, 0.5);
+          sphere_material = new metal(albedo, fuzz);
+          sceneObjects.push_back(new Sphere(center, 0.2, dynamic_cast<material *>(sphere_material)));
+        }
+        else
+        {
+          // glass
+          sphere_material = new dielectric(1.5);
+          sceneObjects.push_back(new Sphere(center, 0.2, dynamic_cast<material *>(sphere_material)));
+        }
+        p_materials.push_back(sphere_material);
+      }
+    }
   }
   auto material1 = new dielectric(1.5);
-  sceneObjects.push_back(new Sphere(point3(0, 1, 0), 1.0, dynamic_cast<material*>(material1)));
+  sceneObjects.push_back(new Sphere(point3(0, 1, 0), 1.0, dynamic_cast<material *>(material1)));
+  p_materials.push_back(material1);
 
   auto material2 = new lambertian(color(0.4, 0.2, 0.1));
-  sceneObjects.push_back(new Sphere(point3(-4, 1, 0), 1.0,  dynamic_cast<material*>(material2)));
+  sceneObjects.push_back(new Sphere(point3(-4, 1, 0), 1.0, dynamic_cast<material *>(material2)));
+  p_materials.push_back(material2);
 
   auto material3 = new metal(color(0.7, 0.6, 0.5), 0.0);
-  sceneObjects.push_back(new Sphere(point3(4, 1, 0), 1.0, dynamic_cast<material*>(material3)));
+  sceneObjects.push_back(new Sphere(point3(4, 1, 0), 1.0, dynamic_cast<material *>(material3)));
+  p_materials.push_back(material3);
 
   BVH world(sceneObjects);
-
 
   point3 lookfrom(13, 2, 3);
   point3 lookat(0, 0, 0);
@@ -167,33 +168,48 @@ int main(int argc, char** argv)
   color *output_image = new color[image_height * image_width];
   double tstart = omp_get_wtime();
 
-  omp_set_num_threads(24);
+  omp_set_num_threads(4);
 #pragma omp parallel shared(output_image, cam)
   {
 #pragma omp for schedule(dynamic)
-  for(int j = image_height - 1; j >= 0; j--)
+    for (int j = image_height - 1; j >= 0; j--)
     {
       // std::cerr << "\rScanlines remaining: " << j << ' ' << omp_get_thread_num() << std::endl;
 
-      for(int i = 0; i < image_width; i++)
+      for (int i = 0; i < image_width; i++)
+      {
+        color pixel_color(0, 0, 0);
+        for (int s = 0; s < samples_per_pixel; ++s)
         {
-          color pixel_color(0, 0, 0);
-          for(int s = 0; s < samples_per_pixel; ++s)
-            {
-              auto u = (i + random_double()) / (image_width - 1);
-              auto v = (j + random_double()) / (image_height - 1);
+          auto u = (i + random_double()) / (image_width - 1);
+          auto v = (j + random_double()) / (image_height - 1);
 
-              ray r = cam.get_ray(u, v);
-              pixel_color += ray_color(r, world, max_depth);
-            }
-          output_image[((image_height - 1 - j)*image_width + i)] = pixel_color;
+          ray r = cam.get_ray(u, v);
+          pixel_color += ray_color(r, world, max_depth);
         }
+        output_image[((image_height - 1 - j) * image_width + i)] = pixel_color;
+      }
     }
   }
 
   double tend = omp_get_wtime();
-  for(int i = 0; i < image_height * image_width; i++)
+  for (int i = 0; i < image_height * image_width; i++)
     write_color(std::cout, output_image[i], samples_per_pixel);
   std::cerr << "\n\nElapsed time: " << tend - tstart << "\n";
   std::cerr << "\nDone.\n";
+
+  //clean up
+  for(int i=0; i<p_materials.size();i++){
+    if(p_materials[i]!=nullptr){
+      delete p_materials[i];
+      p_materials[i]=nullptr;
+    }
+  }
+
+  for(int i=0; i<sceneObjects.size();i++){
+    if(sceneObjects[i]!=nullptr){
+      delete sceneObjects[i];
+      sceneObjects[i]=nullptr;
+    }
+  }
 }

--- a/src/bvh/sphere_bvh.cpp
+++ b/src/bvh/sphere_bvh.cpp
@@ -90,20 +90,18 @@ int main(int argc, char **argv)
 
   // Image
   const auto aspect_ratio = 3.0 / 2.0;
-  const int image_width = 1200;
+  const int image_width = 100;
   const int image_height = static_cast<int>(image_width / aspect_ratio);
-  const int samples_per_pixel = 100;
-  const int max_depth = 10;
+  const int samples_per_pixel = 1;
+  const int max_depth = 1;
 
   // World
   // BVH world(scene_spheres);
 
   std::vector<Sphere *> sceneObjects;
-  std::vector<material *> p_materials;
 
   auto ground_material = new lambertian(color(0.5, 0.5, 0.5));
   sceneObjects.push_back(new Sphere(point3(0, -1000, 0), 1000, dynamic_cast<material *>(ground_material)));
-  p_materials.push_back(ground_material);
 
   for (int a = -11; a < 11; a++)
   {
@@ -137,21 +135,17 @@ int main(int argc, char **argv)
           sphere_material = new dielectric(1.5);
           sceneObjects.push_back(new Sphere(center, 0.2, dynamic_cast<material *>(sphere_material)));
         }
-        p_materials.push_back(sphere_material);
       }
     }
   }
   auto material1 = new dielectric(1.5);
   sceneObjects.push_back(new Sphere(point3(0, 1, 0), 1.0, dynamic_cast<material *>(material1)));
-  p_materials.push_back(material1);
 
   auto material2 = new lambertian(color(0.4, 0.2, 0.1));
   sceneObjects.push_back(new Sphere(point3(-4, 1, 0), 1.0, dynamic_cast<material *>(material2)));
-  p_materials.push_back(material2);
 
   auto material3 = new metal(color(0.7, 0.6, 0.5), 0.0);
   sceneObjects.push_back(new Sphere(point3(4, 1, 0), 1.0, dynamic_cast<material *>(material3)));
-  p_materials.push_back(material3);
 
   BVH world(sceneObjects);
 
@@ -199,17 +193,14 @@ int main(int argc, char **argv)
   std::cerr << "\nDone.\n";
 
   //clean up
-  for(int i=0; i<p_materials.size();i++){
-    if(p_materials[i]!=nullptr){
-      delete p_materials[i];
-      p_materials[i]=nullptr;
-    }
-  }
-
   for(int i=0; i<sceneObjects.size();i++){
     if(sceneObjects[i]!=nullptr){
       delete sceneObjects[i];
       sceneObjects[i]=nullptr;
     }
+  }
+  if(output_image!=nullptr){
+    delete[] output_image;
+    output_image = nullptr;
   }
 }


### PR DESCRIPTION
The memory leaks are cleaned up.  Except those leaks from openmp


Done.
==6060== 
==6060== HEAP SUMMARY:
==6060==     in use at exit: 2,528 bytes in 6 blocks
==6060==   total heap usage: 12,429 allocs, 12,423 frees, 682,293 bytes allocated
==6060== 
==6060== 320 bytes in 1 blocks are possibly lost in loss record 5 of 6
==6060==    at 0x4C33B25: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==6060==    by 0x4013646: allocate_dtv (dl-tls.c:286)
==6060==    by 0x4013646: _dl_allocate_tls (dl-tls.c:530)
==6060==    by 0x5075227: allocate_stack (allocatestack.c:627)
==6060==    by 0x5075227: pthread_create@@GLIBC_2.2.5 (pthread_create.c:644)
==6060==    by 0x4E54F5F: ??? (in /usr/lib/x86_64-linux-gnu/libgomp.so.1.0.0)
==6060==    by 0x4E4BED9: GOMP_parallel (in /usr/lib/x86_64-linux-gnu/libgomp.so.1.0.0)
==6060==    by 0x13D989: raytracing(traceConfig const&) (sphere_bvh_openmp.cpp:84)
==6060==    by 0x10D17F: main (sphere_bvh_openmp.cpp:147)
==6060== 
==6060== LEAK SUMMARY:
==6060==    definitely lost: 0 bytes in 0 blocks
==6060==    indirectly lost: 0 bytes in 0 blocks
==6060==      possibly lost: 320 bytes in 1 blocks
==6060==    still reachable: 2,208 bytes in 5 blocks
==6060==         suppressed: 0 bytes in 0 blocks
==6060== Reachable blocks (those to which a pointer was found) are not shown.
==6060== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==6060== 
==6060== For counts of detected and suppressed errors, rerun with: -v
==6060== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)