### PR TITLE
Benchmark single process openmp

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,8 +30,5 @@ add_subdirectory("common")
 add_subdirectory("bvh")
 add_subdirectory("data_porting")
 add_subdirectory("benchmark")
+add_subdirectory("simple_tracer")
 
-
-add_executable(tracer_marble_single_threaded  "marble_single_thread.cc")
-target_link_libraries(tracer_marble_single_threaded PRIVATE tracer_common PRIVATE OpenMP::OpenMP_CXX)
-target_include_directories(tracer_marble_single_threaded PUBLIC "common")

--- a/src/benchmark/benchmark_bvh.cpp
+++ b/src/benchmark/benchmark_bvh.cpp
@@ -3,25 +3,44 @@
 #include "data_porting.h"
 #include "vec3.h"
 #include "camera.h"
+#include "sphere_generation.h"
+
+static void BM_Baseline_Simple_Tracing_at_sceneSize(benchmark::State &state)
+{
+    int size = state.range(0);
+
+    camera cam = camera::getDefault();
+    // Image
+    const int image_width = 100;
+    const int image_height = static_cast<int>(image_width / cam.aspect_ratio);
+    const int samples_per_pixel = 100;
+    const int max_depth = 4;
+    //create scene
+    SphereGeneration sphereGen;
+    hittable_list world = sphereGen.random_scene_hittablelist(size);
+    //create config
+    traceConfig config(cam, image_width, image_height, max_depth, samples_per_pixel, 1,0,1);
+
+    for (auto _ : state){
+     raytracing_hittablelist(config,world);
+    }
+}
+BENCHMARK(BM_Baseline_Simple_Tracing_at_sceneSize)->Unit(benchmark::kMillisecond)->RangeMultiplier(2)->Range(1,10);
 
 
-static void BM_BVH_Tracing(benchmark::State &state)
+
+static void BM_BVH_Tracing_at_threadNum(benchmark::State &state)
 {
     ShapeDataIO io;
     std::vector<Sphere *> sceneSpheres = io.load_scene("./random_spheres_scene.data");
+
+    camera cam = camera::getDefault();
     // Image
-    const auto aspect_ratio = 3.0 / 2.0;
     const int image_width = 100;
-    const int image_height = static_cast<int>(image_width / aspect_ratio);
+    const int image_height = static_cast<int>(image_width / cam.aspect_ratio);
     const int samples_per_pixel = 100;
     const int max_depth = 3;
     BVH world(sceneSpheres);
-    point3 lookfrom(13, 2, 3);
-    point3 lookat(0, 0, 0);
-    vec3 vup(0, 1, 0);
-    auto dist_to_focus = 10.0;
-    auto aperture = 0.1;
-    camera cam(lookfrom, lookat, vup, 20, aspect_ratio, aperture, dist_to_focus);
 
     int num_threads = state.range(0);
     traceConfig config(cam, image_width, image_height, max_depth, samples_per_pixel, num_threads,0,1);
@@ -32,7 +51,7 @@ static void BM_BVH_Tracing(benchmark::State &state)
     
     io.clear_scene(sceneSpheres);
 }
-BENCHMARK(BM_BVH_Tracing)->RangeMultiplier(2)->Range(1,32);
+BENCHMARK(BM_BVH_Tracing_at_threadNum)->RangeMultiplier(2)->Range(1,32)->Unit(benchmark::kMillisecond);
 
 
 

--- a/src/benchmark/benchmark_bvh.cpp
+++ b/src/benchmark/benchmark_bvh.cpp
@@ -24,14 +24,16 @@ static void BM_BVH_Tracing(benchmark::State &state)
     camera cam(lookfrom, lookat, vup, 20, aspect_ratio, aperture, dist_to_focus);
 
     int num_threads = state.range(0);
-    traceConfig config(cam, world, image_width, image_height, max_depth, samples_per_pixel, num_threads,0,1);
+    traceConfig config(cam, image_width, image_height, max_depth, samples_per_pixel, num_threads,0,1);
 
     for (auto _ : state){
-     raytracing_bvh(config);
+     raytracing_bvh(config,world);
     }
     
     io.clear_scene(sceneSpheres);
 }
 BENCHMARK(BM_BVH_Tracing)->RangeMultiplier(2)->Range(1,32);
+
+
 
 BENCHMARK_MAIN();

--- a/src/bvh/ray_tracing.cpp
+++ b/src/bvh/ray_tracing.cpp
@@ -36,17 +36,15 @@ void printDataSizes(const traceConfig &config){
     std::cerr<<"camera size "<<sizeof(config.cam)<<std::endl;
     std::cerr<<"width size "<<sizeof(config.width)<<std::endl;
     std::cerr<<"height size "<<sizeof(config.height)<<std::endl;
-    std::cerr<<"BVH size "<<sizeof(config.world)<<std::endl;
     std::cerr<<"vec3"<<sizeof(vec3)<<std::endl;
 }
 
-void raytracing_bvh_single_threaded(const traceConfig &config){
+void raytracing_bvh_single_threaded(const traceConfig &config, BVH &world){
     const camera &cam = config.cam;
     const int image_width = config.width;
     const int image_height = config.height;
     const int max_depth = config.traceDepth;
     const int samples_per_pixel = config.samplePerPixel;
-    BVH &world = config.world;
     const int threadNumer = config.numProcs;
 
     printDataSizes(config);
@@ -76,14 +74,13 @@ void raytracing_bvh_single_threaded(const traceConfig &config){
    delete[] out_image;
 }
 
-void raytracing_bvh(const traceConfig &config)
+void raytracing_bvh(const traceConfig &config, BVH &world)
 {
     const camera &cam = config.cam;
     const int image_width = config.width;
     const int image_height = config.height;
     const int max_depth = config.traceDepth;
     const int samples_per_pixel = config.samplePerPixel;
-    BVH &world = config.world;
     const int threadNumer = config.numProcs;
 
     color *out_image = new color[image_width*image_height];

--- a/src/bvh/ray_tracing.cpp
+++ b/src/bvh/ray_tracing.cpp
@@ -31,6 +31,15 @@ color ray_color(const ray &r, BVH &world, int depth)
     return (1.0 - t) * color(1.0, 1.0, 1.0) + t * color(0.5, 0.7, 1.0);
 }
 
+void printDataSizes(const traceConfig &config){
+    std::cerr<<"traceConfig size "<<sizeof(config)<<std::endl;
+    std::cerr<<"camera size "<<sizeof(config.cam)<<std::endl;
+    std::cerr<<"width size "<<sizeof(config.width)<<std::endl;
+    std::cerr<<"height size "<<sizeof(config.height)<<std::endl;
+    std::cerr<<"BVH size "<<sizeof(config.world)<<std::endl;
+    std::cerr<<"vec3"<<sizeof(vec3)<<std::endl;
+}
+
 void raytracing_bvh_single_threaded(const traceConfig &config){
     const camera &cam = config.cam;
     const int image_width = config.width;
@@ -39,6 +48,8 @@ void raytracing_bvh_single_threaded(const traceConfig &config){
     const int samples_per_pixel = config.samplePerPixel;
     BVH &world = config.world;
     const int threadNumer = config.numProcs;
+
+    printDataSizes(config);
 
     color *out_image = new color[image_width*image_height];
 
@@ -61,6 +72,7 @@ void raytracing_bvh_single_threaded(const traceConfig &config){
             }
         }
     }
+    double tend = omp_get_wtime();
    delete[] out_image;
 }
 

--- a/src/bvh/ray_tracing.cpp
+++ b/src/bvh/ray_tracing.cpp
@@ -3,7 +3,29 @@
 #include <omp.h>
 #include "bvh.hpp"
 
-color ray_color(const ray &r, BVH &world, int depth)
+static color ray_color_hittable(const ray &r, const hittable &world, int depth)
+{
+  hit_record rec;
+
+  if (depth <= 0)
+    return color(0, 0, 0);
+
+  if (world.hit(r, 0.001, infinity, rec))
+  {
+    ray scattered;
+    color attenuation;
+
+    if (rec.mat_ptr->scatter(r, rec, attenuation, scattered))
+      return attenuation * ray_color_hittable(scattered, world, depth - 1);
+    return color(0, 0, 0);
+  }
+  vec3 unit_direction = unit_vector(r.direction());
+  auto t = 0.5 * (unit_direction.y() + 1.0);
+
+  return (1.0 - t) * color(1.0, 1.0, 1.0) + t * color(0.5, 0.7, 1.0);
+}
+
+static color ray_color(const ray &r, BVH &world, int depth)
 {
     hit_record rec;
     Sphere *hitObject = nullptr;
@@ -119,4 +141,35 @@ void raytracing_bvh(const traceConfig &config, BVH &world)
     std::cerr << "\n\nElapsed time: " << tend - tstart << "\n";
     std::cerr << "\nDone.\n";
     delete[] out_image;
+}
+
+void raytracing_hittablelist(const traceConfig &config, hittable_list &world){
+    const camera &cam = config.cam;
+    const int image_width = config.width;
+    const int image_height = config.height;
+    const int max_depth = config.traceDepth;
+    const int samples_per_pixel = config.samplePerPixel;
+
+    color *out_image = new color[image_width*image_height];
+
+     for (int j = image_height - 1; j >= 0; j--)
+     {
+    // std::cerr << "\rScanlines remaining: " << j << ' ' << omp_get_thread_num() << std::endl;
+
+    for (int i = 0; i < image_width; i++)
+    {
+      color pixel_color(0, 0, 0);
+      for (int s = 0; s < samples_per_pixel; ++s)
+      {
+        auto u = (i + random_double()) / (image_width - 1);
+        auto v = (j + random_double()) / (image_height - 1);
+
+        ray r = cam.get_ray(u, v);
+        pixel_color += ray_color_hittable(r, world, max_depth);
+      }
+      out_image[((image_height - 1 - j) * image_width + i)] = pixel_color;
+    }
+   }
+  
+
 }

--- a/src/bvh/ray_tracing.cpp
+++ b/src/bvh/ray_tracing.cpp
@@ -5,24 +5,24 @@
 
 static color ray_color_hittable(const ray &r, const hittable &world, int depth)
 {
-  hit_record rec;
+    hit_record rec;
 
-  if (depth <= 0)
-    return color(0, 0, 0);
+    if (depth <= 0)
+        return color(0, 0, 0);
 
-  if (world.hit(r, 0.001, infinity, rec))
-  {
-    ray scattered;
-    color attenuation;
+    if (world.hit(r, 0.001, infinity, rec))
+    {
+        ray scattered;
+        color attenuation;
 
-    if (rec.mat_ptr->scatter(r, rec, attenuation, scattered))
-      return attenuation * ray_color_hittable(scattered, world, depth - 1);
-    return color(0, 0, 0);
-  }
-  vec3 unit_direction = unit_vector(r.direction());
-  auto t = 0.5 * (unit_direction.y() + 1.0);
+        if (rec.mat_ptr->scatter(r, rec, attenuation, scattered))
+            return attenuation * ray_color_hittable(scattered, world, depth - 1);
+        return color(0, 0, 0);
+    }
+    vec3 unit_direction = unit_vector(r.direction());
+    auto t = 0.5 * (unit_direction.y() + 1.0);
 
-  return (1.0 - t) * color(1.0, 1.0, 1.0) + t * color(0.5, 0.7, 1.0);
+    return (1.0 - t) * color(1.0, 1.0, 1.0) + t * color(0.5, 0.7, 1.0);
 }
 
 static color ray_color(const ray &r, BVH &world, int depth)
@@ -53,15 +53,17 @@ static color ray_color(const ray &r, BVH &world, int depth)
     return (1.0 - t) * color(1.0, 1.0, 1.0) + t * color(0.5, 0.7, 1.0);
 }
 
-void printDataSizes(const traceConfig &config){
-    std::cerr<<"traceConfig size "<<sizeof(config)<<std::endl;
-    std::cerr<<"camera size "<<sizeof(config.cam)<<std::endl;
-    std::cerr<<"width size "<<sizeof(config.width)<<std::endl;
-    std::cerr<<"height size "<<sizeof(config.height)<<std::endl;
-    std::cerr<<"vec3"<<sizeof(vec3)<<std::endl;
+void printDataSizes(const traceConfig &config)
+{
+    std::cerr << "traceConfig size " << sizeof(config) << std::endl;
+    std::cerr << "camera size " << sizeof(config.cam) << std::endl;
+    std::cerr << "width size " << sizeof(config.width) << std::endl;
+    std::cerr << "height size " << sizeof(config.height) << std::endl;
+    std::cerr << "vec3" << sizeof(vec3) << std::endl;
 }
 
-void raytracing_bvh_single_threaded(const traceConfig &config, BVH &world){
+void raytracing_bvh_single_threaded(const traceConfig &config, BVH &world)
+{
     const camera &cam = config.cam;
     const int image_width = config.width;
     const int image_height = config.height;
@@ -71,7 +73,7 @@ void raytracing_bvh_single_threaded(const traceConfig &config, BVH &world){
 
     printDataSizes(config);
 
-    color *out_image = new color[image_width*image_height];
+    color *out_image = new color[image_width * image_height];
 
     double tstart = omp_get_wtime();
     {
@@ -93,7 +95,7 @@ void raytracing_bvh_single_threaded(const traceConfig &config, BVH &world){
         }
     }
     double tend = omp_get_wtime();
-   delete[] out_image;
+    delete[] out_image;
 }
 
 void raytracing_bvh(const traceConfig &config, BVH &world)
@@ -105,7 +107,7 @@ void raytracing_bvh(const traceConfig &config, BVH &world)
     const int samples_per_pixel = config.samplePerPixel;
     const int threadNumer = config.numProcs;
 
-    color *out_image = new color[image_width*image_height];
+    color *out_image = new color[image_width * image_height];
 
     omp_set_num_threads(threadNumer);
     double tstart = omp_get_wtime();
@@ -133,43 +135,45 @@ void raytracing_bvh(const traceConfig &config, BVH &world)
     }
 
     double tend = omp_get_wtime();
-    
-    std ::cout << "P3\n"
-               << image_width << ' ' << image_height << "\n255\n";
-    for (int i = 0; i < image_height * image_width; i++)
-        write_color(std::cout, out_image[i], samples_per_pixel);
+
+    if (config.printOutput)
+    {
+        std ::cout << "P3\n"
+                   << image_width << ' ' << image_height << "\n255\n";
+        for (int i = 0; i < image_height * image_width; i++)
+            write_color(std::cout, out_image[i], samples_per_pixel);
     std::cerr << "\n\nElapsed time: " << tend - tstart << "\n";
     std::cerr << "\nDone.\n";
+    }
     delete[] out_image;
 }
 
-void raytracing_hittablelist(const traceConfig &config, hittable_list &world){
+void raytracing_hittablelist(const traceConfig &config, hittable_list &world)
+{
     const camera &cam = config.cam;
     const int image_width = config.width;
     const int image_height = config.height;
     const int max_depth = config.traceDepth;
     const int samples_per_pixel = config.samplePerPixel;
 
-    color *out_image = new color[image_width*image_height];
+    color *out_image = new color[image_width * image_height];
 
-     for (int j = image_height - 1; j >= 0; j--)
-     {
-    // std::cerr << "\rScanlines remaining: " << j << ' ' << omp_get_thread_num() << std::endl;
-
-    for (int i = 0; i < image_width; i++)
+    for (int j = image_height - 1; j >= 0; j--)
     {
-      color pixel_color(0, 0, 0);
-      for (int s = 0; s < samples_per_pixel; ++s)
-      {
-        auto u = (i + random_double()) / (image_width - 1);
-        auto v = (j + random_double()) / (image_height - 1);
+        // std::cerr << "\rScanlines remaining: " << j << ' ' << omp_get_thread_num() << std::endl;
 
-        ray r = cam.get_ray(u, v);
-        pixel_color += ray_color_hittable(r, world, max_depth);
-      }
-      out_image[((image_height - 1 - j) * image_width + i)] = pixel_color;
+        for (int i = 0; i < image_width; i++)
+        {
+            color pixel_color(0, 0, 0);
+            for (int s = 0; s < samples_per_pixel; ++s)
+            {
+                auto u = (i + random_double()) / (image_width - 1);
+                auto v = (j + random_double()) / (image_height - 1);
+
+                ray r = cam.get_ray(u, v);
+                pixel_color += ray_color_hittable(r, world, max_depth);
+            }
+            out_image[((image_height - 1 - j) * image_width + i)] = pixel_color;
+        }
     }
-   }
-  
-
 }

--- a/src/bvh/ray_tracing.h
+++ b/src/bvh/ray_tracing.h
@@ -8,7 +8,6 @@
 struct traceConfig
 {
     camera& cam;
-    BVH& world;
     int width;
     int height;
     int traceDepth;
@@ -16,8 +15,8 @@ struct traceConfig
     int numProcs;
     int myRank;
     int threadsPerProc;
-    traceConfig(camera &_cam, BVH &_world, int _width, int _height, int _depth, int _sample, int _numProcs, int _myRank, int _threads_per_proc)
-    :cam(_cam), world(_world), width(_width), height(_height), traceDepth(_depth), samplePerPixel(_sample),
+    traceConfig(camera &_cam, int _width, int _height, int _depth, int _sample, int _numProcs, int _myRank, int _threads_per_proc)
+    :cam(_cam), width(_width), height(_height), traceDepth(_depth), samplePerPixel(_sample),
      numProcs(_numProcs), myRank(_myRank), threadsPerProc(_threads_per_proc)
   {}
 };
@@ -25,13 +24,13 @@ struct traceConfig
 /**
  * @brief openmp version of bvh tracing
  */
-void raytracing_bvh(const traceConfig &config);
+void raytracing_bvh(const traceConfig &config, BVH &world);
 
 /**
  * @brief a single thread bvh tracing for debug and profiling purpose. This method is 
  * free of mpi or openmp premitives.
  */
-void raytracing_bvh_single_threaded(const traceConfig &config);
+void raytracing_bvh_single_threaded(const traceConfig &config, BVH &world);
 
 
 color ray_color(const ray &r, BVH &world, int depth);

--- a/src/bvh/ray_tracing.h
+++ b/src/bvh/ray_tracing.h
@@ -10,6 +10,7 @@
 struct traceConfig
 {
     camera& cam;
+    bool printOutput;
     int width;
     int height;
     int traceDepth;
@@ -17,10 +18,8 @@ struct traceConfig
     int numProcs;
     int myRank;
     int threadsPerProc;
-    traceConfig(camera &_cam, int _width, int _height, int _depth, int _sample, int _numProcs, int _myRank, int _threads_per_proc)
-    :cam(_cam), width(_width), height(_height), traceDepth(_depth), samplePerPixel(_sample),
-     numProcs(_numProcs), myRank(_myRank), threadsPerProc(_threads_per_proc)
-  {}
+    traceConfig(camera &_cam, int _width, int _height, int _depth, int _sample, int _numProcs, int _myRank, int _threads_per_proc): traceConfig(_cam, _width, _height, _depth, _sample, _numProcs, _myRank, _threads_per_proc, false){}
+    traceConfig(camera &_cam, int _width, int _height, int _depth, int _sample, int _numProcs, int _myRank, int _threads_per_proc, bool _print_output)    :cam(_cam), width(_width), height(_height), traceDepth(_depth), samplePerPixel(_sample), numProcs(_numProcs), myRank(_myRank), threadsPerProc(_threads_per_proc), printOutput(_print_output){}
 };
 
 /**

--- a/src/bvh/ray_tracing.h
+++ b/src/bvh/ray_tracing.h
@@ -4,6 +4,8 @@
 #include "bvh.hpp"
 #include "camera.h"
 #include "color.h"
+#include "hittable_list.h"
+#include "hittable.h"
 
 struct traceConfig
 {
@@ -32,6 +34,7 @@ void raytracing_bvh(const traceConfig &config, BVH &world);
  */
 void raytracing_bvh_single_threaded(const traceConfig &config, BVH &world);
 
+void raytracing_hittablelist(const traceConfig &config, hittable_list &world);
 
-color ray_color(const ray &r, BVH &world, int depth);
+
 #endif

--- a/src/bvh/sphere_bvh_mpi.cpp
+++ b/src/bvh/sphere_bvh_mpi.cpp
@@ -10,7 +10,7 @@
 #include <omp.h>
 #include "ray_tracing.h"
 
-void raytracing(const traceConfig config){
+void raytracing(const traceConfig config, BVH& world){
     const camera &cam = config.cam;
     const int image_width = config.width;
     const int image_height = config.height;
@@ -22,8 +22,6 @@ void raytracing(const traceConfig config){
 
     if(config.myRank == config.numProcs - 1)
       my_row_start = image_height;
-
-    BVH &world = config.world;
 
     std::cerr << "Process " << config.myRank
               << " rendering rows " << my_row_end
@@ -185,9 +183,9 @@ int main(int argc, char **argv)
   auto aperture = 0.1;
   camera cam(lookfrom, lookat, vup, 20, aspect_ratio, aperture, dist_to_focus);
 
-  traceConfig config(cam, world, image_width, image_height, max_depth, samples_per_pixel, nprocs, my_rank, num_threads);
+  traceConfig config(cam, image_width, image_height, max_depth, samples_per_pixel, nprocs, my_rank, num_threads);
 
-  raytracing(config);
+  raytracing(config, world);
   if(my_rank == 0)
     {
       std::cerr << "\nDone.\n";

--- a/src/bvh/sphere_bvh_mpi.cpp
+++ b/src/bvh/sphere_bvh_mpi.cpp
@@ -10,6 +10,34 @@
 #include <omp.h>
 #include "ray_tracing.h"
 
+color ray_color(const ray &r, BVH &world, int depth)
+{
+    hit_record rec;
+    Sphere *hitObject = nullptr;
+
+    if (depth <= 0)
+        return color(0, 0, 0);
+
+    if (world.intersect(r, &hitObject, rec))
+    {
+        ray scattered;
+        color attenuation;
+        if (rec.mat_ptr->scatter(r, rec, attenuation, scattered))
+        {
+            return attenuation * ray_color(scattered, world, depth - 1);
+        }
+        else
+        {
+            return color(0, 0, 0);
+        }
+    }
+
+    //otherwise return the background color
+    vec3 unit_direction = unit_vector(r.direction());
+    auto t = 0.5 * (unit_direction.y() + 1.0);
+    return (1.0 - t) * color(1.0, 1.0, 1.0) + t * color(0.5, 0.7, 1.0);
+}
+
 void raytracing(const traceConfig config, BVH& world){
     const camera &cam = config.cam;
     const int image_width = config.width;

--- a/src/bvh/sphere_bvh_openmp.cpp
+++ b/src/bvh/sphere_bvh_openmp.cpp
@@ -31,7 +31,6 @@ int main(int argc, char** argv)
 
   // World
   BVH world(scene_spheres);
-
   point3 lookfrom(13, 2, 3);
   point3 lookat(0, 0, 0);
   vec3 vup(0, 1, 0);
@@ -39,9 +38,9 @@ int main(int argc, char** argv)
   auto aperture = 0.1;
   camera cam(lookfrom, lookat, vup, 20, aspect_ratio, aperture, dist_to_focus);
 
-  traceConfig config(cam, world, image_width, image_height, max_depth, samples_per_pixel, num_threads, 0, 1);
+  traceConfig config(cam, image_width, image_height, max_depth, samples_per_pixel, num_threads, 0, 1);
 
-  raytracing_bvh(config);
+  raytracing_bvh(config, world);
   std::cerr << "\nDone.\n";
   shapeIO.clear_scene(scene_spheres);
 }

--- a/src/bvh/sphere_bvh_single.cpp
+++ b/src/bvh/sphere_bvh_single.cpp
@@ -37,9 +37,9 @@ int main(int argc, char** argv)
   auto aperture = 0.1;
   camera cam(lookfrom, lookat, vup, 20, aspect_ratio, aperture, dist_to_focus);
 
-  traceConfig config(cam, world, image_width, image_height, max_depth, samples_per_pixel, 1, 0, 1);
+  traceConfig config(cam, image_width, image_height, max_depth, samples_per_pixel, 1, 0, 1);
 
-  raytracing_bvh_single_threaded(config);
+  raytracing_bvh_single_threaded(config, world);
 
   shapeIO.clear_scene(scene_spheres);
 }

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_library(tracer_common OBJECT "vec3.cpp" "sphere.cpp" "color.cpp" "common.cpp")
+add_library(tracer_common OBJECT "vec3.cpp" "sphere.cpp" "color.cpp" "common.cpp" "hittable_list.cpp")
 target_include_directories(tracer_common PUBLIC ".")

--- a/src/common/camera.h
+++ b/src/common/camera.h
@@ -6,12 +6,14 @@ class camera
 {
 public:
   camera(point3 lookfrom, point3 lookat, vec3 vup,
-         double vfov, double aspect_ratio,
-         double aperture, double focus_dist
-       )
+         double vfov, double aspect_ratio_,
+         double aperture, double focus_dist)
   {
+
+    aspect_ratio = aspect_ratio_;
+
     auto theta = degrees_to_radians(vfov);
-    auto h = tan(theta/2);
+    auto h = tan(theta / 2);
     auto viewport_height = 2.0 * h;
     auto viewport_width = aspect_ratio * viewport_height;
 
@@ -20,9 +22,11 @@ public:
     v = cross(w, u);
 
     origin = lookfrom;
-    horizontal = focus_dist * viewport_width * u;;
-    vertical = focus_dist * viewport_height * v;;
-    lower_left_corner = origin - horizontal/2 - vertical/2 - focus_dist*w;
+    horizontal = focus_dist * viewport_width * u;
+    ;
+    vertical = focus_dist * viewport_height * v;
+    ;
+    lower_left_corner = origin - horizontal / 2 - vertical / 2 - focus_dist * w;
 
     lens_radius = aperture / 2;
   }
@@ -30,19 +34,31 @@ public:
   ray get_ray(double s, double t) const
   {
     vec3 rd = lens_radius * random_in_unit_disk();
-    vec3 offset = u * rd.x() + v*rd.y();
+    vec3 offset = u * rd.x() + v * rd.y();
     return ray(origin + offset,
-               lower_left_corner + s*horizontal + t*vertical - origin - offset);
+               lower_left_corner + s * horizontal + t * vertical - origin - offset);
+  }
+
+  static camera getDefault()
+  {
+    // Image
+    const auto aspect_ratio = 3.0 / 2.0;
+    point3 lookfrom(13, 2, 3);
+    point3 lookat(0, 0, 0);
+    vec3 vup(0, 1, 0);
+    auto dist_to_focus = 10.0;
+    auto aperture = 0.1;
+    return camera(lookfrom, lookat, vup, 20, aspect_ratio, aperture, dist_to_focus);
   }
 
 public:
   point3 origin;
   point3 lower_left_corner;
+  double aspect_ratio;
   vec3 horizontal;
   vec3 vertical;
   vec3 u, v, w;
   double lens_radius;
-
 };
 
 #endif // CAMERA_HH_INCLUDED

--- a/src/common/hittable_list.cpp
+++ b/src/common/hittable_list.cpp
@@ -1,0 +1,21 @@
+#include "hittable_list.h"
+#include "ray.h"
+
+bool hittable_list::hit(const ray& r, double t_min, double t_max, hit_record& rec) const
+{
+  hit_record temp_rec;
+  bool hit_anything = false;
+
+  auto closest_so_far = t_max;
+
+  for(const auto& object : objects)
+    {
+      if(object->hit(r, t_min, closest_so_far, temp_rec))
+        {
+          hit_anything = true;
+          closest_so_far = temp_rec.t;
+          rec = temp_rec;
+        }
+    }
+  return hit_anything;
+}

--- a/src/common/hittable_list.h
+++ b/src/common/hittable_list.h
@@ -22,24 +22,4 @@ class hittable_list : public hittable
 public:
   std::vector<unique_ptr<hittable>> objects;
 };
-
-bool hittable_list::hit(const ray& r, double t_min, double t_max, hit_record& rec) const
-{
-  hit_record temp_rec;
-  bool hit_anything = false;
-
-  auto closest_so_far = t_max;
-
-  for(const auto& object : objects)
-    {
-      if(object->hit(r, t_min, closest_so_far, temp_rec))
-        {
-          hit_anything = true;
-          closest_so_far = temp_rec.t;
-          rec = temp_rec;
-        }
-    }
-  return hit_anything;
-}
-
 #endif // HITTABLE_LIST_HH_INCLUDED

--- a/src/data_porting/CMakeLists.txt
+++ b/src/data_porting/CMakeLists.txt
@@ -12,7 +12,7 @@
  
  
  add_library(shapeio OBJECT "data_porting.cpp" "sphere_generation.cpp")
- target_link_libraries(shapeio PRIVATE nlohmann_json::nlohmann_json bvhlib)
+ target_link_libraries(shapeio PRIVATE nlohmann_json::nlohmann_json bvhlib tracer_common)
  target_include_directories(shapeio PRIVATE "../common/" "../bvh")
  
 add_executable(shapeio_main "data_main.cpp")

--- a/src/data_porting/CMakeLists.txt
+++ b/src/data_porting/CMakeLists.txt
@@ -11,7 +11,7 @@
  endif()
  
  
- add_library(shapeio OBJECT "data_porting.cpp")
+ add_library(shapeio OBJECT "data_porting.cpp" "sphere_generation.cpp")
  target_link_libraries(shapeio PRIVATE nlohmann_json::nlohmann_json bvhlib)
  target_include_directories(shapeio PRIVATE "../common/" "../bvh")
  

--- a/src/data_porting/sphere_gen.cpp
+++ b/src/data_porting/sphere_gen.cpp
@@ -5,61 +5,7 @@
 #include "sphere.h"
 #include "common.h"
 #include <nlohmann/json.hpp>
-
-std::vector<sphere*> random_scene(int size)
-{
-    std::vector<sphere*> output;
-
-  auto ground_material = make_unique<lambertian>(color(0.5, 0.5, 0.5));
-  output.push_back(new sphere(point3(0, -1000, 0), 1000, std::move(ground_material)));
-
-  for (int a = -1*size; a < size; a++)
-  {
-    for (int b = -1*size; b < size; b++)
-    {
-      auto choose_mat = random_double();
-      point3 center(a + 0.9 * random_double(), 0.2, b + 0.9 * random_double());
-
-      if ((center - point3(4, 0.2, 0)).length() > 0.9)
-      {
-        unique_ptr<material> sphere_material;
-
-        if (choose_mat < 0.8)
-        {
-          // diffuse
-          auto albedo = color::random() * color::random();
-          sphere_material = make_unique<lambertian>(albedo);
-          output.push_back(new sphere(center, 0.2, std::move(sphere_material)));
-        }
-        else if (choose_mat < 0.95)
-        {
-          // metal
-          auto albedo = color::random(0.5, 1);
-          auto fuzz = random_double(0, 0.5);
-          sphere_material = make_unique<metal>(albedo, fuzz);
-          output.push_back(new sphere(center, 0.2, std::move(sphere_material)));
-        }
-        else
-        {
-          // glass
-          sphere_material = make_unique<dielectric>(1.5);
-          output.push_back(new sphere(center, 0.2, std::move(sphere_material)));
-        }
-      }
-    }
-  }
-
-  auto material1 = make_unique<dielectric>(1.5);
-  output.push_back(new sphere(point3(0, 1, 0), 1.0, std::move(material1)));
-
-  auto material2 = make_unique<lambertian>(color(0.4, 0.2, 0.1));
-  output.push_back(new sphere(point3(-4, 1, 0), 1.0, std::move(material2)));
-
-  auto material3 = make_unique<metal>(color(0.7, 0.6, 0.5), 0.0);
-  output.push_back(new sphere(point3(4, 1, 0), 1.0, std::move(material3)));
-
-  return output;
-}
+#include "sphere_generation.h"
 
 int main(int argc, char **argv){
     if(argc<2){
@@ -68,12 +14,12 @@ int main(int argc, char **argv){
     }
     int size = atoi(argv[1]);
     ShapeDataIO io;
-    auto spheres = random_scene(size);
+    SphereGeneration sg;
+    auto spheres = sg.random_scene_spheres(size);
     nlohmann::json spheresJson = io.serialize(spheres);
     io.write("random_spheres_scene.data", spheresJson);
     auto readJson = io.read("random_spheres_scene.data");
     auto readSpheres = io.deserialize_Spheres(readJson);
-
     std::cout<<readSpheres.size()<<" records are generated."<<std::endl;
     return 0;
 }

--- a/src/data_porting/sphere_generation.cpp
+++ b/src/data_porting/sphere_generation.cpp
@@ -1,4 +1,63 @@
 #include "sphere_generation.h"
+#include "hittable_list.h"
+#include "boundable.h"
+
+hittable_list SphereGeneration::random_scene_hittablelist(int size)
+{
+  hittable_list output;
+
+  auto ground_material = make_unique<lambertian>(color(0.5, 0.5, 0.5));
+  output.add(make_unique<sphere>(point3(0, -1000, 0), 1000, std::move(ground_material)));
+
+  for (int a = -1*size; a < size; a++)
+  {
+    for (int b = -1*size; b < size; b++)
+    {
+      auto choose_mat = random_double();
+      point3 center(a + 0.9 * random_double(), 0.2, b + 0.9 * random_double());
+
+      if ((center - point3(4, 0.2, 0)).length() > 0.9)
+      {
+        unique_ptr<material> sphere_material;
+
+        if (choose_mat < 0.8)
+        {
+          // diffuse
+          auto albedo = color::random() * color::random();
+          sphere_material = make_unique<lambertian>(albedo);
+          output.add(make_unique<sphere>(center, 0.2, std::move(sphere_material)));
+        }
+        else if (choose_mat < 0.95)
+        {
+          // metal
+          auto albedo = color::random(0.5, 1);
+          auto fuzz = random_double(0, 0.5);
+          sphere_material = make_unique<metal>(albedo, fuzz);
+          output.add(make_unique<sphere>(center, 0.2, std::move(sphere_material)));
+        }
+        else
+        {
+          // glass
+          sphere_material = make_unique<dielectric>(1.5);
+          output.add(make_unique<sphere>(center, 0.2, std::move(sphere_material)));
+        }
+      }
+    }
+  }
+
+  auto material1 = make_unique<dielectric>(1.5);
+  output.add(make_unique<sphere>(point3(0, 1, 0), 1.0, std::move(material1)));
+
+  auto material2 = make_unique<lambertian>(color(0.4, 0.2, 0.1));
+  output.add(make_unique<sphere>(point3(-4, 1, 0), 1.0, std::move(material2)));
+
+  auto material3 = make_unique<metal>(color(0.7, 0.6, 0.5), 0.0);
+  output.add(make_unique<sphere>(point3(4, 1, 0), 1.0, std::move(material3)));
+
+  return output;  
+}
+
+
 
 std::vector<sphere*> SphereGeneration::random_scene_spheres(int size)
 {

--- a/src/data_porting/sphere_generation.cpp
+++ b/src/data_porting/sphere_generation.cpp
@@ -1,0 +1,114 @@
+#include "sphere_generation.h"
+
+std::vector<sphere*> SphereGeneration::random_scene_spheres(int size)
+{
+    std::vector<sphere*> output;
+
+  auto ground_material = make_unique<lambertian>(color(0.5, 0.5, 0.5));
+  output.push_back(new sphere(point3(0, -1000, 0), 1000, std::move(ground_material)));
+
+  for (int a = -1*size; a < size; a++)
+  {
+    for (int b = -1*size; b < size; b++)
+    {
+      auto choose_mat = random_double();
+      point3 center(a + 0.9 * random_double(), 0.2, b + 0.9 * random_double());
+
+      if ((center - point3(4, 0.2, 0)).length() > 0.9)
+      {
+        unique_ptr<material> sphere_material;
+
+        if (choose_mat < 0.8)
+        {
+          // diffuse
+          auto albedo = color::random() * color::random();
+          sphere_material = make_unique<lambertian>(albedo);
+          output.push_back(new sphere(center, 0.2, std::move(sphere_material)));
+        }
+        else if (choose_mat < 0.95)
+        {
+          // metal
+          auto albedo = color::random(0.5, 1);
+          auto fuzz = random_double(0, 0.5);
+          sphere_material = make_unique<metal>(albedo, fuzz);
+          output.push_back(new sphere(center, 0.2, std::move(sphere_material)));
+        }
+        else
+        {
+          // glass
+          sphere_material = make_unique<dielectric>(1.5);
+          output.push_back(new sphere(center, 0.2, std::move(sphere_material)));
+        }
+      }
+    }
+  }
+
+  auto material1 = make_unique<dielectric>(1.5);
+  output.push_back(new sphere(point3(0, 1, 0), 1.0, std::move(material1)));
+
+  auto material2 = make_unique<lambertian>(color(0.4, 0.2, 0.1));
+  output.push_back(new sphere(point3(-4, 1, 0), 1.0, std::move(material2)));
+
+  auto material3 = make_unique<metal>(color(0.7, 0.6, 0.5), 0.0);
+  output.push_back(new sphere(point3(4, 1, 0), 1.0, std::move(material3)));
+
+  return output;
+}
+
+std::vector<Sphere*> SphereGeneration::random_scene_Spheres(int size)
+{
+    std::vector<Sphere*> output;
+
+  auto ground_material = new lambertian(color(0.5, 0.5, 0.5));
+  output.push_back(new Sphere(point3(0, -1000, 0), 1000, ground_material));
+
+  for (int a = -1*size; a < size; a++)
+  {
+    for (int b = -1*size; b < size; b++)
+    {
+      auto choose_mat = random_double();
+      point3 center(a + 0.9 * random_double(), 0.2, b + 0.9 * random_double());
+
+      if ((center - point3(4, 0.2, 0)).length() > 0.9)
+      {
+        material* sphere_material;
+
+        if (choose_mat < 0.8)
+        {
+          // diffuse
+          auto albedo = color::random() * color::random();
+          sphere_material = new lambertian(albedo);
+          output.push_back(new Sphere(center, 0.2, sphere_material));
+        }
+        else if (choose_mat < 0.95)
+        {
+          // metal
+          auto albedo = color::random(0.5, 1);
+          auto fuzz = random_double(0, 0.5);
+          sphere_material = new metal(albedo, fuzz);
+          output.push_back(new Sphere(center, 0.2, sphere_material));
+        }
+        else
+        {
+          // glass
+          sphere_material = new dielectric(1.5);
+          output.push_back(new Sphere(center, 0.2, sphere_material));
+        }
+      }
+    }
+  }
+
+  auto material1 = new dielectric(1.5);
+  output.push_back(new Sphere(point3(0, 1, 0), 1.0, material1));
+
+  auto material2 = new lambertian(color(0.4, 0.2, 0.1));
+  output.push_back(new Sphere(point3(-4, 1, 0), 1.0, material2));
+
+  auto material3 = new metal(color(0.7, 0.6, 0.5), 0.0);
+  output.push_back(new Sphere(point3(4, 1, 0), 1.0, material3));
+
+  return output;
+}
+
+
+

--- a/src/data_porting/sphere_generation.h
+++ b/src/data_porting/sphere_generation.h
@@ -1,0 +1,13 @@
+#ifndef __H__SPHERE_GEN__
+#define __H__SPHERE_GEN__
+#include <vector>
+#include "sphere.h"
+#include "boundable.h"
+
+class SphereGeneration
+{
+    public:
+    std::vector<sphere*> random_scene_spheres(int size);
+    std::vector<Sphere*> random_scene_Spheres(int size);
+};
+#endif

--- a/src/data_porting/sphere_generation.h
+++ b/src/data_porting/sphere_generation.h
@@ -3,10 +3,12 @@
 #include <vector>
 #include "sphere.h"
 #include "boundable.h"
+#include "hittable_list.h"
 
 class SphereGeneration
 {
     public:
+    hittable_list random_scene_hittablelist(int size);
     std::vector<sphere*> random_scene_spheres(int size);
     std::vector<Sphere*> random_scene_Spheres(int size);
 };

--- a/src/simple_tracer/CMakeLists.txt
+++ b/src/simple_tracer/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(tracer_marble_single_threaded  "marble_single_thread.cc")
+target_link_libraries(tracer_marble_single_threaded PRIVATE tracer_common PRIVATE OpenMP::OpenMP_CXX)
+target_include_directories(tracer_marble_single_threaded PUBLIC "../common")

--- a/src/simple_tracer/CMakeLists.txt
+++ b/src/simple_tracer/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_executable(tracer_marble_single_threaded  "marble_single_thread.cc")
-target_link_libraries(tracer_marble_single_threaded PRIVATE tracer_common PRIVATE OpenMP::OpenMP_CXX)
-target_include_directories(tracer_marble_single_threaded PUBLIC "../common")
+target_link_libraries(tracer_marble_single_threaded PRIVATE tracer_common PRIVATE OpenMP::OpenMP_CXX shapeio bvhlib)
+target_include_directories(tracer_marble_single_threaded PUBLIC "../common" "../data_porting" "../bvh")

--- a/src/simple_tracer/marble_single_thread.cc
+++ b/src/simple_tracer/marble_single_thread.cc
@@ -130,10 +130,6 @@ int main()
   color *output_image = new color[image_height * image_width];
   double tstart = omp_get_wtime();
 
-  omp_set_num_threads(8);
-#pragma omp parallel shared(output_image, cam)
-  {
-#pragma omp for schedule(dynamic)
   for(int j = image_height - 1; j >= 0; j--)
     {
       // std::cerr << "\rScanlines remaining: " << j << ' ' << omp_get_thread_num() << std::endl;
@@ -152,7 +148,6 @@ int main()
           output_image[((image_height - 1 - j)*image_width + i)] = pixel_color;
         }
     }
-  }
   double tend = omp_get_wtime();
   for(int i = 0; i < image_height * image_width; i++)
     write_color(std::cout, output_image[i], samples_per_pixel);

--- a/src/simple_tracer/marble_single_thread.cc
+++ b/src/simple_tracer/marble_single_thread.cc
@@ -9,6 +9,7 @@
 #include "material.h"
 #include <cassert>
 #include "sphere_generation.h"
+#include "ray_tracing.h"
 
 hittable_list static_scene()
 {
@@ -22,80 +23,37 @@ hittable_list static_scene()
   auto metal_material = make_unique<metal>(albedo, fuzz);
 
   world.add(make_unique<sphere>(point3(0, -1000, 0), 1000, std::move(ground_material)));
-  world.add(make_unique<sphere>(point3(5,1.5,1),1,std::move(glass_material)));
-  world.add(make_unique<sphere>(point3(1,1,1),1,std::move(metal_material)));
+  world.add(make_unique<sphere>(point3(5, 1.5, 1), 1, std::move(glass_material)));
+  world.add(make_unique<sphere>(point3(1, 1, 1), 1, std::move(metal_material)));
   return world;
-}
-
-color ray_color(const ray &r, const hittable &world, int depth)
-{
-  hit_record rec;
-
-  if (depth <= 0)
-    return color(0, 0, 0);
-
-  if (world.hit(r, 0.001, infinity, rec))
-  {
-    ray scattered;
-    color attenuation;
-
-    if (rec.mat_ptr->scatter(r, rec, attenuation, scattered))
-      return attenuation * ray_color(scattered, world, depth - 1);
-    return color(0, 0, 0);
-  }
-  vec3 unit_direction = unit_vector(r.direction());
-  auto t = 0.5 * (unit_direction.y() + 1.0);
-
-  return (1.0 - t) * color(1.0, 1.0, 1.0) + t * color(0.5, 0.7, 1.0);
 }
 
 int main()
 {
 
-  // Image
-  const auto aspect_ratio = 3.0 / 2.0;
-  const int image_width = 1200;
-  const int image_height = static_cast<int>(image_width / aspect_ratio);
-  const int samples_per_pixel = 500;
-  const int max_depth = 10;
-
   SphereGeneration scene_generator;
   // World
   auto world = scene_generator.random_scene_hittablelist(11);
+  camera cam = camera::getDefault();
 
-  point3 lookfrom(13, 2, 3);
-  point3 lookat(0, 0, 0);
-  vec3 vup(0, 1, 0);
-  auto dist_to_focus = 10.0;
-  auto aperture = 0.1;
-  camera cam(lookfrom, lookat, vup, 20, aspect_ratio, aperture, dist_to_focus);
+  //trace property
+  const int image_width = 1200;
+  const int image_height = static_cast<int>(image_width / cam.aspect_ratio);
+  const int samples_per_pixel = 500;
+  const int max_depth = 10;
+
+  color *output_image = new color[image_height * image_width];
+  traceConfig config(cam, image_width, image_height, max_depth, samples_per_pixel,1,0,1);
+
 
   std ::cout << "P3\n"
              << image_width << ' ' << image_height << "\n255\n";
 
-  color *output_image = new color[image_height * image_width];
   double tstart = omp_get_wtime();
-
-  for(int j = image_height - 1; j >= 0; j--)
-    {
-      // std::cerr << "\rScanlines remaining: " << j << ' ' << omp_get_thread_num() << std::endl;
-
-      for(int i = 0; i < image_width; i++)
-        {
-          color pixel_color(0, 0, 0);
-          for(int s = 0; s < samples_per_pixel; ++s)
-            {
-              auto u = (i + random_double()) / (image_width - 1);
-              auto v = (j + random_double()) / (image_height - 1);
-
-              ray r = cam.get_ray(u, v);
-              pixel_color += ray_color(r, world, max_depth);
-            }
-          output_image[((image_height - 1 - j)*image_width + i)] = pixel_color;
-        }
-    }
+  raytracing_hittablelist(config, world);
   double tend = omp_get_wtime();
-  for(int i = 0; i < image_height * image_width; i++)
+
+  for (int i = 0; i < image_height * image_width; i++)
     write_color(std::cout, output_image[i], samples_per_pixel);
 
   std::cerr << "\n\nElapsed time: " << tend - tstart << "\n";

--- a/src/simple_tracer/marble_single_thread.cc
+++ b/src/simple_tracer/marble_single_thread.cc
@@ -8,6 +8,7 @@
 #include "camera.h"
 #include "material.h"
 #include <cassert>
+#include "sphere_generation.h"
 
 hittable_list static_scene()
 {
@@ -23,62 +24,6 @@ hittable_list static_scene()
   world.add(make_unique<sphere>(point3(0, -1000, 0), 1000, std::move(ground_material)));
   world.add(make_unique<sphere>(point3(5,1.5,1),1,std::move(glass_material)));
   world.add(make_unique<sphere>(point3(1,1,1),1,std::move(metal_material)));
-  return world;
-}
-
-hittable_list random_scene()
-{
-  hittable_list world;
-
-  auto ground_material = make_unique<lambertian>(color(0.5, 0.5, 0.5));
-  world.add(make_unique<sphere>(point3(0, -1000, 0), 1000, std::move(ground_material)));
-
-  for (int a = -11; a < 11; a++)
-    {
-      for(int b = -11; b < 11; b++)
-        {
-          auto choose_mat = random_double();
-          point3 center(a+0.9*random_double(), 0.2, b + 0.9*random_double());
-
-          if((center - point3(4, 0.2, 0)).length() > 0.9)
-            {
-              unique_ptr<material> sphere_material;
-
-              if(choose_mat < 0.8)
-                {
-                  // diffuse
-                  auto albedo = color::random() * color::random();
-                  sphere_material = make_unique<lambertian>(albedo);
-                  world.add(make_unique<sphere>(center, 0.2, std::move(sphere_material)));
-
-                }
-              else if(choose_mat < 0.95)
-                {
-                  // metal
-                  auto albedo = color::random(0.5, 1);
-                  auto fuzz = random_double(0, 0.5);
-                  sphere_material = make_unique<metal>(albedo, fuzz);
-                  world.add(make_unique<sphere>(center, 0.2, std::move(sphere_material)));
-                }
-              else
-                {
-                  // glass
-                  sphere_material = make_unique<dielectric>(1.5);
-                  world.add(make_unique<sphere>(center, 0.2, std::move(sphere_material)));
-
-                }
-            }
-        }
-  }
-  auto material1 = make_unique<dielectric>(1.5);
-  world.add(make_unique<sphere>(point3(0, 1, 0), 1.0, std::move(material1)));
-
-  auto material2 = make_unique<lambertian>(color(0.4, 0.2, 0.1));
-  world.add(make_unique<sphere>(point3(-4, 1, 0), 1.0, std::move(material2)));
-
-  auto material3 = make_unique<metal>(color(0.7, 0.6, 0.5), 0.0);
-  world.add(make_unique<sphere>(point3(4, 1, 0), 1.0, std::move(material3)));
-
   return world;
 }
 
@@ -114,8 +59,9 @@ int main()
   const int samples_per_pixel = 500;
   const int max_depth = 10;
 
+  SphereGeneration scene_generator;
   // World
-  auto world = random_scene();
+  auto world = scene_generator.random_scene_hittablelist(11);
 
   point3 lookfrom(13, 2, 3);
   point3 lookat(0, 0, 0);


### PR DESCRIPTION
Refactor to single out the ray tracing function from the original marble-single-thread-simple-tracer, so that it can be benchmarked.
Add in code for benchmarking performance of simple tracer at different scene size