### PR TITLE
add tile decomposition

### DIFF
--- a/src/benchmark/benchmark_bvh.cpp
+++ b/src/benchmark/benchmark_bvh.cpp
@@ -53,8 +53,31 @@ static void BM_Baseline_BVH_Tracing_at_sceneSize(benchmark::State &state)
 }
 BENCHMARK(BM_Baseline_BVH_Tracing_at_sceneSize)->Unit(benchmark::kMillisecond)->RangeMultiplier(2)->Range(1,10);
 
+static void BM_BVH_Tracing_OMP_threadsNum_tileSize(benchmark::State &state)
+{
+    int num_thread=state.range(0);
+    int tileSize = state.range(1);
+    ShapeDataIO io;
 
+    camera cam = camera::getDefault();
+    // Image
+    const int image_width = 1200;
+    const int image_height = static_cast<int>(image_width / cam.aspect_ratio);
+    const int samples_per_pixel = 10;
+    const int max_depth = 5;
+    //create scene
+    SphereGeneration sphereGen;
+    std::vector<Sphere*> spheres = sphereGen.random_scene_Spheres(5);
+    BVH world(spheres);
+    //create config
+    traceConfig config(cam, image_width, image_height, max_depth, samples_per_pixel, num_thread,0,1);
 
+    for (auto _ : state){
+     raytracing_bvh_tiled(config,world,tileSize);
+    }
+    io.clear_scene(spheres);
+}
+BENCHMARK(BM_BVH_Tracing_OMP_threadsNum_tileSize)->Unit(benchmark::kMillisecond)->RangeMultiplier(2)->Ranges({{1, 8}, {1, 64}});
 
 static void BM_BVH_Tracing_at_threadNum(benchmark::State &state)
 {
@@ -63,10 +86,10 @@ static void BM_BVH_Tracing_at_threadNum(benchmark::State &state)
 
     camera cam = camera::getDefault();
     // Image
-    const int image_width = 100;
+    const int image_width = 1200;
     const int image_height = static_cast<int>(image_width / cam.aspect_ratio);
-    const int samples_per_pixel = 100;
-    const int max_depth = 3;
+    const int samples_per_pixel = 10;
+    const int max_depth = 5;
     BVH world(sceneSpheres);
 
     int num_threads = state.range(0);

--- a/src/bvh/CMakeLists.txt
+++ b/src/bvh/CMakeLists.txt
@@ -16,6 +16,11 @@ if(OpenMP_CXX_FOUND)
   target_include_directories(bvh_mt PUBLIC "../common/" "../data_porting" "./")
   target_link_libraries(bvh_mt bvhlib tracer_common shapeio nlohmann_json::nlohmann_json OpenMP::OpenMP_CXX)
 
+# an executable for multiple thread bvh
+  add_executable(bvh_mt_tiled "sphere_bvh_openmp_tiled.cpp")
+  target_include_directories(bvh_mt_tiled PUBLIC "../common/" "../data_porting" "./")
+  target_link_libraries(bvh_mt_tiled bvhlib tracer_common shapeio nlohmann_json::nlohmann_json OpenMP::OpenMP_CXX)
+
 # an executable for single thread bvh
   add_executable(sphere_bvh_single "sphere_bvh_single.cpp")
   target_include_directories(sphere_bvh_single PUBLIC "../common/" "../data_porting" "./")

--- a/src/bvh/bvh_test.cpp
+++ b/src/bvh/bvh_test.cpp
@@ -2,6 +2,7 @@
 #include "boundable.h"
 #include "bvh.hpp"
 #include "ray.h"
+#include "ray_tracing.h"
 
 TEST(SanityCheck, testcase1)
 {
@@ -292,3 +293,42 @@ TEST(bvh, create_BVH_1_object_b){
     
     sceneObjects.clear();
 }
+
+void assert_right_tile_indexes(int w, int h, int t_s, int id, int exp_sr, int exp_sc, int exp_er, int exp_ec){
+    int startRow=-1;
+    int startCol=-1;
+    int endRow=-1;
+    int endCol=-1;
+    getTileIndexes(w, h, t_s, id, startRow, startCol, endRow, endCol);
+    ASSERT_EQ(exp_sr, startRow)<<"id "<<id;
+    ASSERT_EQ(exp_er, endRow)<<"id "<<id;
+    ASSERT_EQ(exp_sc, startCol)<<"id "<<id;
+    ASSERT_EQ(exp_ec, endCol)<<"id "<<id;
+}
+
+TEST(ray_tracing, tile_indexes_calculation){
+    {
+    int width = 16;
+    int height = 16;
+    int tileSize = 8;
+    assert_right_tile_indexes(width, height, tileSize,0,0,0,8,8);
+    assert_right_tile_indexes(width, height, tileSize,1,0,8,8,16);
+    assert_right_tile_indexes(width, height, tileSize,2,8,0,16,8);
+    assert_right_tile_indexes(width, height, tileSize,3,8,8,16,16);
+    }
+    {
+    int width = 17;
+    int height = 17;
+    int tileSize = 8;
+    assert_right_tile_indexes(width, height, tileSize,0,0,0,8,8);
+    assert_right_tile_indexes(width, height, tileSize,1,0,8,8,16);
+    assert_right_tile_indexes(width, height, tileSize,2,0,16,8,17);
+    assert_right_tile_indexes(width, height, tileSize,3,8,0,16,8);
+    assert_right_tile_indexes(width, height, tileSize,4,8,8,16,16);
+    assert_right_tile_indexes(width, height, tileSize,5,8,16,16,17);
+    assert_right_tile_indexes(width, height, tileSize,6,16,0,17,8);
+    assert_right_tile_indexes(width, height, tileSize,7,16,8,17,16);
+    assert_right_tile_indexes(width, height, tileSize,8,16,16,17,17);
+    }
+}
+

--- a/src/bvh/ray_tracing.h
+++ b/src/bvh/ray_tracing.h
@@ -35,5 +35,7 @@ void raytracing_bvh_single_threaded(const traceConfig &config, BVH &world);
 
 void raytracing_hittablelist(const traceConfig &config, hittable_list &world);
 
+bool getTileIndexes(const int width, const int height, const int tileSize, const int id, int &startRow, int &startCol, int &endRow, int &endCol);
+void raytracing_bvh_tiled(const traceConfig &config, BVH &world, const int tileSize);
 
 #endif

--- a/src/bvh/sphere_bvh_openmp_tiled.cpp
+++ b/src/bvh/sphere_bvh_openmp_tiled.cpp
@@ -1,0 +1,39 @@
+#include "bvh.hpp"
+#include "ray_tracing.h"
+#include "data_porting.h"
+#include "vec3.h"
+#include "camera.h"
+#include <vector>
+#include "color.h"
+#include <ctime>
+#include "boundable.h"
+
+int main(int argc, char** argv)
+{
+
+  if(argc<4){
+    std::cerr<<"Usage:"<<argv[0]<<" sceneFile num_threads tileSize"<<std::endl;
+    exit(1);
+  }
+
+  ShapeDataIO shapeIO;
+  std::string sceneFile = argv[1];
+  std::vector<Sphere*> scene_spheres = shapeIO.load_scene(sceneFile);
+  int num_threads = std::atoi(argv[2]);
+  int tileSize = std::atoi(argv[3]);
+  std::cerr << "Rendering scene " << sceneFile << " using " << num_threads << " threads with tilesize "<<tileSize<<std::endl;
+
+    camera cam = camera::getDefault();
+    // Image
+    const int image_width = 640;
+    const int image_height = static_cast<int>(image_width / cam.aspect_ratio);
+    const int samples_per_pixel = 100;
+    const int max_depth = 10;
+
+    // World
+    BVH world(scene_spheres);
+    traceConfig config(cam, image_width, image_height, max_depth, samples_per_pixel, num_threads, 0, 1, true);
+    raytracing_bvh_tiled(config, world,tileSize);
+    std::cerr << "\nDone.\n";
+    shapeIO.clear_scene(scene_spheres);
+}


### PR DESCRIPTION
Run on (8 X 3401 MHz CPU s)
2021-05-03 01:21:58
***WARNING*** Library was built as DEBUG. Timings may be affected.
-----------------------------------------------------------------------------------
Benchmark                                            Time           CPU Iterations
-----------------------------------------------------------------------------------
BM_Baseline_Simple_Tracing_at_sceneSize/1         1507 ms       1500 ms          1
BM_Baseline_Simple_Tracing_at_sceneSize/2         2557 ms       2562 ms          1
BM_Baseline_Simple_Tracing_at_sceneSize/4         6859 ms       6844 ms          1
BM_Baseline_Simple_Tracing_at_sceneSize/8        25014 ms      25000 ms          1
BM_Baseline_Simple_Tracing_at_sceneSize/10       38675 ms      38594 ms          1
BM_Baseline_BVH_Tracing_at_sceneSize/1            1067 ms       1062 ms          1
BM_Baseline_BVH_Tracing_at_sceneSize/2            1142 ms       1141 ms          1
BM_Baseline_BVH_Tracing_at_sceneSize/4            1375 ms       1375 ms          1
BM_Baseline_BVH_Tracing_at_sceneSize/8            2109 ms       2109 ms          1
BM_Baseline_BVH_Tracing_at_sceneSize/10           2205 ms       2203 ms          1
BM_BVH_Tracing_OMP_threadsNum_tileSize/1/1       23913 ms      23891 ms          1
BM_BVH_Tracing_OMP_threadsNum_tileSize/2/1       12887 ms      12828 ms          1
BM_BVH_Tracing_OMP_threadsNum_tileSize/4/1        7851 ms       7797 ms          1
BM_BVH_Tracing_OMP_threadsNum_tileSize/8/1        6051 ms       5422 ms          1
BM_BVH_Tracing_OMP_threadsNum_tileSize/1/2       23364 ms      23375 ms          1
BM_BVH_Tracing_OMP_threadsNum_tileSize/2/2       12505 ms      12438 ms          1
BM_BVH_Tracing_OMP_threadsNum_tileSize/4/2        7643 ms       7484 ms          1
BM_BVH_Tracing_OMP_threadsNum_tileSize/8/2        6129 ms       5328 ms          1
BM_BVH_Tracing_OMP_threadsNum_tileSize/1/4       23785 ms      23797 ms          1
BM_BVH_Tracing_OMP_threadsNum_tileSize/2/4       12590 ms      12516 ms          1
BM_BVH_Tracing_OMP_threadsNum_tileSize/4/4        7627 ms       7609 ms          1
BM_BVH_Tracing_OMP_threadsNum_tileSize/8/4        5912 ms       5500 ms          1
BM_BVH_Tracing_OMP_threadsNum_tileSize/1/8       24423 ms      24359 ms          1
BM_BVH_Tracing_OMP_threadsNum_tileSize/2/8       12566 ms      12547 ms          1
BM_BVH_Tracing_OMP_threadsNum_tileSize/4/8        7500 ms       7391 ms          1
BM_BVH_Tracing_OMP_threadsNum_tileSize/8/8        5996 ms       5594 ms          1
BM_BVH_Tracing_OMP_threadsNum_tileSize/1/16      23740 ms      23734 ms          1
BM_BVH_Tracing_OMP_threadsNum_tileSize/2/16      12271 ms      12250 ms          1
BM_BVH_Tracing_OMP_threadsNum_tileSize/4/16       7658 ms       7516 ms          1
BM_BVH_Tracing_OMP_threadsNum_tileSize/8/16       5868 ms       5469 ms          1
BM_BVH_Tracing_OMP_threadsNum_tileSize/1/32      24448 ms      24406 ms          1
BM_BVH_Tracing_OMP_threadsNum_tileSize/2/32      12927 ms      12906 ms          1
BM_BVH_Tracing_OMP_threadsNum_tileSize/4/32       7740 ms       7672 ms          1
BM_BVH_Tracing_OMP_threadsNum_tileSize/8/32       5764 ms       5469 ms          1
BM_BVH_Tracing_OMP_threadsNum_tileSize/1/64      24376 ms      24328 ms          1
BM_BVH_Tracing_OMP_threadsNum_tileSize/2/64      12589 ms      12594 ms          1
BM_BVH_Tracing_OMP_threadsNum_tileSize/4/64       8008 ms       7328 ms          1
BM_BVH_Tracing_OMP_threadsNum_tileSize/8/64       5983 ms       5281 ms          1
BM_BVH_Tracing_at_threadNum/1                    24307 ms      24266 ms          1
BM_BVH_Tracing_at_threadNum/2                    12692 ms      12672 ms          1
BM_BVH_Tracing_at_threadNum/4                     7606 ms       7609 ms          1
BM_BVH_Tracing_at_threadNum/8                     5860 ms       5406 ms          1
BM_BVH_Tracing_at_threadNum/16                    5792 ms       2656 ms          1
BM_BVH_Tracing_at_threadNum/32                    5785 ms       1219 ms          1