### PR TITLE
add ability to run benchmark on cc

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Need to set up singularity image, see procedure under Environment Setup
 ```bash
 #has to be in the root directory of ParRay i.e. at level where you see ./src, ./README.md
 #make sure you have the singularity container set up.
-qsub ./scripts/batch_script.slurm
+qsub ./scripts/batch_script_full.slurm
 ```
 
 # Environment Setup
@@ -69,6 +69,13 @@ On campus cluster
 ```bash
 module load singularity
 cd ~/scratch 						    #The current scripts assume the singularity container is in ~/scratch
-singularity build cs484.sif docker://cjf12harry/cs484:0.0.1 #build a singularity container from docker image, we cannot reuse the course container due to old cmake version
+singularity build cs484.sif docker://cjf12harry/cs484:0.0.2 #build a singularity container from docker image, we cannot reuse the course container due to old cmake version
+```
+
+To test the set up, use the provided light script
+
+```bash
+cd ParRay
+qsub ./scripts/batch_script_light.slurm
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ mpiexec -np 6 --bind-to none ./bin/bvh_mpi random_spheres_scene.data 4 > img.ppm
 ```bash
 ./build/bin/bm_ray_tracing
 ```
+
+## Run on Campus Cluster
+Need to set up singularity image, see procedure under Environment Setup
+```bash
+#has to be in the root directory of ParRay i.e. at level where you see ./src, ./README.md
+#make sure you have the singularity container set up.
+qsub ./scripts/batch_script.slurm
+```
+
 # Environment Setup
 The unit test requires CMake version at least 3.11 to run, due to the FetchContent() module.
 
@@ -53,5 +62,13 @@ To install google benchmark in ubuntu run the following command
 ```
 sudo apt-get update
 sudo apt-get install libbenchmark-dev
+```
+
+### Campus Cluster Environtment setup
+On campus cluster
+```bash
+module load singularity
+cd ~/scratch 						    #The current scripts assume the singularity container is in ~/scratch
+singularity build cs484.sif docker://cjf12harry/cs484:0.0.1 #build a singularity container from docker image, we cannot reuse the course container due to old cmake version
 ```
 

--- a/scripts/batch_script.slurm
+++ b/scripts/batch_script.slurm
@@ -1,0 +1,65 @@
+#!/bin/bash
+#SBATCH --time=01:20:00
+#SBATCH --nodes=2
+#SBATCH --ntasks-per-node=16
+#SBATCH --exclusive
+#SBATCH --job-name parRay-team7
+#SBATCH -p cs
+#PBS -S ~/scratch/sing_shell.sh
+
+echo `whoami`
+## If not started with PBS, figure out where we are relative to the build directory
+#####Snippet from:   http://stackoverflow.com/questions/59895/
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+#####end snippet
+echo $SCRIPT_DIR
+#IF SLURM_SUBMIT_DIR is not set, we are not running in PBS, choose directory relative to script.
+SLURM_SUBMIT_DIR=${SLURM_SUBMIT_DIR:-${SCRIPT_DIR}/..}
+echo $SLURM_SUBMIT_DIR
+#moves to the directory the user was in when they ran qsub
+cd ${SLURM_SUBMIT_DIR} #assumed to be the source tree
+
+#check that the script was submit from the right place.
+if [ -d "./src" ]
+then
+	echo "We seem to be in the right place."
+else
+	echo "Not submit from the right place! Submit from the root of your repository."
+	exit 1
+fi
+
+if [ -d "./build"]
+then
+	rm -rf ./build
+fi
+
+
+#creates an out-of-tree build directory for CMake and moves to it
+mkdir -p ${SLURM_SUBMIT_DIR}/build
+pushd ${SLURM_SUBMIT_DIR}/build
+
+echo "Compiling"
+srun --mpi=pmi2 --ntasks 1 ~/scratch/sing_exec.sh cmake ${SLURM_SUBMIT_DIR}/src && \
+srun --mpi=pmi2 --ntasks 1 ~/scratch/sing_exec.sh make
+
+echo "Run Tests"
+srun --mpi=pmi2 --ntasks 1 ~/scratch/sing_exec.sh  ./bin/bvh_test
+srun --mpi=pmi2 --ntasks 1 ~/scratch/sing_exec.sh  ./bin/data_porting_test
+
+
+pushd ${SLURM_SUBMIT_DIR}/build/bin
+
+echo "Run Benchmarks"
+srun --mpi=pmi2 --ntasks 1 ~/scratch/sing_exec.sh  ./bin/bm_ray_tracing 
+srun --mpi=pmi2 --ntasks 1 ~/scratch/sing_exec.sh  ./gen_random_scene 5
+
+
+for N_CPUS in 1 4 9 16 25 36
+do
+
+	#Individual MPI run
+	echo "Doing MPI CPUS = ${N_CPUS} "
+#	srun --mpi=pmi2 --ntasks-per-node ${SLURM_NTASKS_PER_NODE} --cpu-bind=cores --ntasks ${N_CPUS} ~/scratch/sing_exec.sh ./bin/bm_mpi ./random_spheres_scene.data 2
+	srun --mpi=pmi2 --cpu-bind=cores --ntasks ${N_CPUS} ~/scratch/sing_exec.sh ./bm_mpi ./random_spheres_scene.data 2
+done
+

--- a/scripts/batch_script.slurm
+++ b/scripts/batch_script.slurm
@@ -5,7 +5,7 @@
 #SBATCH --exclusive
 #SBATCH --job-name parRay-team7
 #SBATCH -p cs
-#PBS -S ~/scratch/sing_shell.sh
+#PBS -S ./scripts/sing_shell.sh
 
 echo `whoami`
 ## If not started with PBS, figure out where we are relative to the build directory
@@ -33,33 +33,35 @@ then
 	rm -rf ./build
 fi
 
+SING_EXEC_LOCATION=${SLURM_SUBMIT_DIR}/scripts/sing_exec.sh
+SING_SH_LOCATION=${SLURM_SUBMIT_DIR}/scripts/sing_shell.sh
+BIN_DIR=${SLURM_SUBMIT_DIR}/build/bin
 
 #creates an out-of-tree build directory for CMake and moves to it
 mkdir -p ${SLURM_SUBMIT_DIR}/build
 pushd ${SLURM_SUBMIT_DIR}/build
 
 echo "Compiling"
-srun --mpi=pmi2 --ntasks 1 ~/scratch/sing_exec.sh cmake ${SLURM_SUBMIT_DIR}/src && \
-srun --mpi=pmi2 --ntasks 1 ~/scratch/sing_exec.sh make
+srun --mpi=pmi2 --ntasks 1 ${SING_EXEC_LOCATION} cmake ${SLURM_SUBMIT_DIR}/src && \
+srun --mpi=pmi2 --ntasks 1 ${SING_EXEC_LOCATION} make
 
 echo "Run Tests"
-srun --mpi=pmi2 --ntasks 1 ~/scratch/sing_exec.sh  ./bin/bvh_test
-srun --mpi=pmi2 --ntasks 1 ~/scratch/sing_exec.sh  ./bin/data_porting_test
+srun --mpi=pmi2 --ntasks 1 ${SING_EXEC_LOCATION}  "${BIN_DIR}/bvh_test"
+srun --mpi=pmi2 --ntasks 1 ${SING_EXEC_LOCATION}  "${BIN_DIR}/data_porting_test"
 
 
-pushd ${SLURM_SUBMIT_DIR}/build/bin
 
 echo "Run Benchmarks"
-srun --mpi=pmi2 --ntasks 1 ~/scratch/sing_exec.sh  ./bin/bm_ray_tracing 
-srun --mpi=pmi2 --ntasks 1 ~/scratch/sing_exec.sh  ./gen_random_scene 5
+#srun --mpi=pmi2 --ntasks 1 ~/scratch/sing_exec.sh  ./bin/bm_ray_tracing 
+srun --mpi=pmi2 --ntasks 1 ${SING_EXEC_LOCATION}  "${BIN_DIR}/gen_random_scene 5"
 
 
-for N_CPUS in 1 4 9 16 25 36
+for N_CPUS in 1 2 4 8 16 32 64
 do
 
 	#Individual MPI run
 	echo "Doing MPI CPUS = ${N_CPUS} "
 #	srun --mpi=pmi2 --ntasks-per-node ${SLURM_NTASKS_PER_NODE} --cpu-bind=cores --ntasks ${N_CPUS} ~/scratch/sing_exec.sh ./bin/bm_mpi ./random_spheres_scene.data 2
-	srun --mpi=pmi2 --cpu-bind=cores --ntasks ${N_CPUS} ~/scratch/sing_exec.sh ./bm_mpi ./random_spheres_scene.data 2
+	srun --mpi=pmi2 --cpu-bind=cores --ntasks ${N_CPUS} ${SING_EXEC_LOCATION} "${BIN_DIR}/bm_mpi ./random_spheres_scene.data 2"
 done
 

--- a/scripts/batch_script_full.slurm
+++ b/scripts/batch_script_full.slurm
@@ -1,0 +1,65 @@
+#!/bin/bash
+#SBATCH --time=01:20:00
+#SBATCH --nodes=2
+#SBATCH --ntasks-per-node=16
+#SBATCH --exclusive
+#SBATCH --job-name parRay-team7
+#SBATCH -p cs
+#PBS -S ./scripts/sing_shell.sh
+
+echo `whoami`
+## If not started with PBS, figure out where we are relative to the build directory
+#####Snippet from:   http://stackoverflow.com/questions/59895/
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+#####end snippet
+echo $SCRIPT_DIR
+#IF SLURM_SUBMIT_DIR is not set, we are not running in PBS, choose directory relative to script.
+SLURM_SUBMIT_DIR=${SLURM_SUBMIT_DIR:-${SCRIPT_DIR}/..}
+echo $SLURM_SUBMIT_DIR
+#moves to the directory the user was in when they ran qsub
+cd ${SLURM_SUBMIT_DIR} #assumed to be the source tree
+
+#check that the script was submit from the right place.
+if [ -d "./src" ]
+then
+	echo "We seem to be in the right place."
+else
+	echo "Not submit from the right place! Submit from the root of your repository."
+	exit 1
+fi
+
+if [ -d "./build" ]
+then
+	rm -rf ./build
+fi
+
+SING_EXEC_LOCATION=${SLURM_SUBMIT_DIR}/scripts/sing_exec.sh
+SING_SH_LOCATION=${SLURM_SUBMIT_DIR}/scripts/sing_shell.sh
+BIN_DIR=${SLURM_SUBMIT_DIR}/build/bin
+
+#creates an out-of-tree build directory for CMake and moves to it
+mkdir -p ${SLURM_SUBMIT_DIR}/build
+pushd ${SLURM_SUBMIT_DIR}/build
+
+echo "Compiling"
+srun --mpi=pmi2 --ntasks 1 --nnode 1  ${SING_EXEC_LOCATION} cmake ${SLURM_SUBMIT_DIR}/src && \
+srun --mpi=pmi2 --ntasks 1 --nnode 1  ${SING_EXEC_LOCATION} make
+
+echo "Run Tests"
+srun --mpi=pmi2 --ntasks 1 --nnode 1 ${SING_EXEC_LOCATION}  "${BIN_DIR}/bvh_test"
+srun --mpi=pmi2 --ntasks 1 --nnode 1 ${SING_EXEC_LOCATION}  "${BIN_DIR}/data_porting_test"
+
+echo "Run Benchmarks"
+srun --mpi=pmi2 --ntasks 1 ${SING_EXEC_LOCATION}  "${BIN_DIR}/bm_ray_tracing"
+srun --mpi=pmi2 --ntasks 1 --nnode 1 ${SING_EXEC_LOCATION}  "${BIN_DIR}/gen_random_scene 10"
+
+
+for N_CPUS in 1 2 4 8 16
+do
+
+	#Individual MPI run
+	echo "Doing MPI CPUS = ${N_CPUS} "
+#	srun --mpi=pmi2 --ntasks-per-node ${SLURM_NTASKS_PER_NODE} --cpu-bind=cores --ntasks ${N_CPUS} ~/scratch/sing_exec.sh ./bin/bm_mpi ./random_spheres_scene.data 2
+	srun --mpi=pmi2 --cpu-bind=cores --ntasks ${N_CPUS} ${SING_EXEC_LOCATION} "${BIN_DIR}/bm_mpi ./random_spheres_scene.data 2"
+done
+

--- a/scripts/batch_script_light.slurm
+++ b/scripts/batch_script_light.slurm
@@ -1,0 +1,67 @@
+#!/bin/bash
+#SBATCH --time=01:20:00
+#SBATCH --nodes=2
+#SBATCH --ntasks-per-node=16
+#SBATCH --exclusive
+#SBATCH --job-name parRay-team7
+#SBATCH -p cs
+#PBS -S ./scripts/sing_shell.sh
+
+echo `whoami`
+## If not started with PBS, figure out where we are relative to the build directory
+#####Snippet from:   http://stackoverflow.com/questions/59895/
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+#####end snippet
+echo $SCRIPT_DIR
+#IF SLURM_SUBMIT_DIR is not set, we are not running in PBS, choose directory relative to script.
+SLURM_SUBMIT_DIR=${SLURM_SUBMIT_DIR:-${SCRIPT_DIR}/..}
+echo $SLURM_SUBMIT_DIR
+#moves to the directory the user was in when they ran qsub
+cd ${SLURM_SUBMIT_DIR} #assumed to be the source tree
+
+#check that the script was submit from the right place.
+if [ -d "./src" ]
+then
+	echo "We seem to be in the right place."
+else
+	echo "Not submit from the right place! Submit from the root of your repository."
+	exit 1
+fi
+
+if [ -d "./build" ]
+then
+	rm -rf ./build
+fi
+
+SING_EXEC_LOCATION=${SLURM_SUBMIT_DIR}/scripts/sing_exec.sh
+SING_SH_LOCATION=${SLURM_SUBMIT_DIR}/scripts/sing_shell.sh
+BIN_DIR=${SLURM_SUBMIT_DIR}/build/bin
+
+#creates an out-of-tree build directory for CMake and moves to it
+mkdir -p ${SLURM_SUBMIT_DIR}/build
+pushd ${SLURM_SUBMIT_DIR}/build
+
+echo "Compiling"
+srun --mpi=pmi2 --ntasks 1 --nodes=1 ${SING_EXEC_LOCATION} cmake ${SLURM_SUBMIT_DIR}/src && \
+srun --mpi=pmi2 --ntasks 1 --nodes=1 ${SING_EXEC_LOCATION} make
+
+echo "Run Tests"
+srun --mpi=pmi2 --ntasks 1 --nodes=1 ${SING_EXEC_LOCATION}  "${BIN_DIR}/bvh_test"
+srun --mpi=pmi2 --ntasks 1  --nodes=1 ${SING_EXEC_LOCATION}  "${BIN_DIR}/data_porting_test"
+
+
+
+echo "Run Benchmarks"
+#srun --mpi=pmi2 --ntasks 1 ~/scratch/sing_exec.sh  ./bin/bm_ray_tracing 
+srun --mpi=pmi2 --ntasks 1 --nodes=1 ${SING_EXEC_LOCATION}  "${BIN_DIR}/gen_random_scene 5"
+
+
+for N_CPUS in 2
+do
+
+	#Individual MPI run
+	echo "Doing MPI CPUS = ${N_CPUS} "
+#	srun --mpi=pmi2 --ntasks-per-node ${SLURM_NTASKS_PER_NODE} --cpu-bind=cores --ntasks ${N_CPUS} ~/scratch/sing_exec.sh ./bin/bm_mpi ./random_spheres_scene.data 2
+	srun --mpi=pmi2 --cpu-bind=cores --ntasks ${N_CPUS} ${SING_EXEC_LOCATION} "${BIN_DIR}/bm_mpi ./random_spheres_scene.data 2"
+done
+

--- a/scripts/sing_exec.sh
+++ b/scripts/sing_exec.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+source /etc/profile.d/modules.sh
+
+module load singularity
+#SINGULARITYENV_APPEND_PATH=/lib64/mpich-3.2/bin/
+exec singularity exec -B /scratch:/scratch -B /var/spool/torque:/var/spool/torque ~/scratch/cs484.sif ${*}

--- a/scripts/sing_shell.sh
+++ b/scripts/sing_shell.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+source /etc/profile.d/modules.sh
+
+module load singularity
+#SINGULARITYENV_APPEND_PATH=/lib64/mpich-3.2/bin/
+exec singularity shell -B /scratch:/scratch -B /var/spool/torque:/var/spool/torque ~/scratch/cs484.sif ${*}

--- a/src/benchmark/benchmark_bvh_mpi.cpp
+++ b/src/benchmark/benchmark_bvh_mpi.cpp
@@ -185,7 +185,7 @@ void mpi_benchmark(benchmark::State &state)
   }
   if(rank==0){
     for(int i=0;i<nprocs;i++){
-      char label[10];
+      char label[128];
       snprintf(label,sizeof(label),"process%i",i);
       std::string slabel=label;
       state.counters[slabel] = perCpuTime[i];


### PR DESCRIPTION
updated readme with instructions to run benchmarking on cc
updated script folder to offer 2 flavors of the run script, light-for smoke testing of environment, full-for full benchmark.